### PR TITLE
Modify using of scripts and authorization to users can use scripts for users

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/scriptler/ScritplerPluginImpl.java
+++ b/src/main/java/org/jvnet/hudson/plugins/scriptler/ScritplerPluginImpl.java
@@ -88,7 +88,7 @@ public class ScritplerPluginImpl extends Plugin {
 		// if not, add it to the configuration
 		for (File file : availablePhysicalScripts) {
 			if (cfg.getScriptByName(file.getName()) == null) {
-				cfg.addOrReplace(new Script(file.getName(), Messages.script_loaded_from_directory()));
+				cfg.addOrReplace(new Script(file.getName(), Messages.script_loaded_from_directory(), false));
 			}
 		}
 
@@ -97,7 +97,7 @@ public class ScritplerPluginImpl extends Plugin {
 		Set<Script> unavailableScripts = new HashSet<Script>();
 		for (Script s : cfg.getScripts()) {
 			if (!(new File(scriptDirectory, s.name).exists())) {
-				unavailableScripts.add(new Script(s.name, s.comment, false));
+				unavailableScripts.add(new Script(s.name, s.comment, false, false));
 			}
 		}
 		for (Script script : unavailableScripts) {

--- a/src/main/java/org/jvnet/hudson/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jvnet/hudson/plugins/scriptler/config/Script.java
@@ -39,24 +39,38 @@ public class Script implements Comparable<Script>, NamedResource {
 	 * the file system. Therefore it has to be materialized before usage!
 	 */
 	public transient String script;
+        //for user with overall permission read
+        public boolean nonAdministerUsing;
 
 	@DataBoundConstructor
-	public Script(String name, String comment) {
+	public Script(String name, String comment, boolean nonAdministerUsing) {
 		this.name = name;
 		this.comment = comment;
 		this.available = true;
 		this.originCatalog = null;
 		this.originScript = null;
 		this.originDate = null;
+                this.nonAdministerUsing=nonAdministerUsing;
+	}
+        
+        public Script(String name, String comment) {
+		this.name = name;
+		this.comment = comment;
+		this.available = true;
+		this.originCatalog = null;
+		this.originScript = null;
+		this.originDate = null;
+                this.nonAdministerUsing=false;
 	}
 
-	public Script(String name, String comment, boolean available) {
+	public Script(String name, String comment, boolean available,boolean nonAdministerUsing) {
 		this.name = name;
 		this.comment = comment;
 		this.available = available;
 		this.originCatalog = null;
 		this.originScript = null;
 		this.originDate = null;
+                this.nonAdministerUsing=nonAdministerUsing;
 	}
 
 	/**
@@ -76,6 +90,19 @@ public class Script implements Comparable<Script>, NamedResource {
 		this.originCatalog = originCatalog;
 		this.originScript = originScript;
 		this.originDate = originDate;
+                this.nonAdministerUsing=false;
+                
+	}
+        
+        public Script(String name, String comment, boolean available, String originCatalog, String originScript, String originDate, boolean nonAdministerUsing) {
+		this.name = name;
+		this.comment = comment;
+		this.available = available;
+		this.originCatalog = originCatalog;
+		this.originScript = originScript;
+		this.originDate = originDate;
+                this.nonAdministerUsing=nonAdministerUsing;
+                
 	}
 
 	/*
@@ -89,6 +116,10 @@ public class Script implements Comparable<Script>, NamedResource {
 
 	public void setScript(String script) {
 		this.script = script;
+	}
+        
+        public void setNonAdministerUsing(boolean nonAdministerUsing) {
+		this.nonAdministerUsing = nonAdministerUsing;
 	}
 
 	/*

--- a/src/main/java/org/jvnet/hudson/plugins/scriptler/config/ScriptSet.java
+++ b/src/main/java/org/jvnet/hudson/plugins/scriptler/config/ScriptSet.java
@@ -70,11 +70,21 @@ public class ScriptSet {
 		String originCatalog = StringUtils.isEmpty(newScript.originCatalog) ? origin.originCatalog : newScript.originCatalog;
 		String originScript = StringUtils.isEmpty(newScript.originScript) ? origin.originScript : newScript.originScript;
 		String originDate = StringUtils.isEmpty(newScript.originDate) ? origin.originDate : newScript.originDate;
-		return new Script(origin.getName(), comment, newScript.available, originCatalog, originScript, originDate);
+		return new Script(origin.getName(), comment, newScript.available, originCatalog, originScript, originDate,newScript.nonAdministerUsing);
 	}
 
 	public final Set<Script> getScripts() {
 		return Collections.unmodifiableSet(scriptSet);
+	}
+        
+        public final Set<Script> getUserScripts() {
+                Set<Script> userScripts = new TreeSet<Script>();
+                for(Script script: scriptSet){
+                    if(script.nonAdministerUsing){
+                        userScripts.add(script);
+                    }
+                }
+		return userScripts;
 	}
 
 	public void setScripts(Set<Script> scripts) {
@@ -82,3 +92,4 @@ public class ScriptSet {
 	}
 
 }
+

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/edit.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/edit.jelly
@@ -48,6 +48,9 @@ THE SOFTWARE.
 					<f:entry title="${%Comment}">
 						<f:textbox name="comment" value="${script.comment}" />
 					</f:entry>
+                                        <f:entry title="${%Permission}">
+						<f:checkbox name="nonAdministerUsing" checked="${script.nonAdministerUsing}" />
+					</f:entry>
 					<f:entry title="${%Script}">
 						<textarea id="script" name="script" style="width:100%; height:20em">
 							<j:out value="${script.script}" />

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/edit.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/edit.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 title=Edit Script
 uploadtext=Select a Groovy script from your local system to be uploaded this will overwrite the current file.
+Permission = Enable to user with overall permission read

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/index.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<l:layout permission="${app.ADMINISTER}" norefresh="true">
+	<l:layout permission="${app.READ}" norefresh="true">
 		<!--
 			<st:include it="${it.primaryView}" page="sidepanel.jelly"
 			xmlns:st="jelly:stapler" />
@@ -48,7 +48,15 @@ THE SOFTWARE.
 	                <h3><j:out value="${%noScriptsAvailable}" /></h3>
 	            </j:if>
 				<table class="pane">
-					<j:forEach var="t" items="${it.configuration.scripts}">
+                                    <j:choose>
+                                        <j:when test="${app.ADMINISTER==null or h.hasPermission(it,app.ADMINISTER)}">
+                                            <j:set var="items" value = "${it.configuration.scripts}"/>
+                                        </j:when>
+                                        <j:otherwise>
+                                            <j:set var="items" value = "${it.configuration.UserScripts}"/>
+                                        </j:otherwise>
+                                    </j:choose>
+					<j:forEach var="t" items="${items}">
 						<tr valign="center" style="border-top: 0px;">
 							<td class="pane" width="70">
 								<j:choose>
@@ -61,15 +69,17 @@ THE SOFTWARE.
 									</j:otherwise>
 								</j:choose>
 								<j:out value=" " />
-								<a href="editScript?name=${t.name}">
+                                                                <j:if test="${app.ADMINISTER==null or h.hasPermission(it,app.ADMINISTER)}">
+                                                                    <a href="editScript?name=${t.name}">
 									<img width="16" height="16" title="${%edit script} ${t.name}"
 										src="${imagesURL }/16x16/document_edit.gif" />
-								</a>
-								<j:out value=" " />
-								<a href="removeScript?name=${t.name}">
+                                                                    </a>
+                                                                    <j:out value=" " />
+                                                                    <a href="removeScript?name=${t.name}">
 									<img width="16" height="16" title="${%remove script} ${t.name}"
 										src="${imagesURL}/16x16/edit-delete.gif" />
-								</a>
+                                                                    </a>
+                                                                </j:if>
 								<j:out value=" " />
 								<a href="runScript?name=${t.name}">
 									<img width="16" height="16" title="${%run script} ${t.name}"

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/scriptsettings.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/scriptsettings.jelly
@@ -49,6 +49,9 @@
 				<f:entry title="${%Comment}">
 					<f:textbox name="comment" />
 				</f:entry>
+                                <f:entry title="${%Permission}">
+					<f:checkbox name="nonAdministerUsing" />
+				</f:entry>
 				<f:entry title="${%Script}">
 					<textarea id="script" name="script" style="width:100%; height:20em">
 					</textarea>
@@ -64,6 +67,10 @@
               </div>
 			<f:form method="post" action="uploadScript" name="uploadScript"
 				enctype="multipart/form-data">
+                                    
+                                <f:entry title="${%Permission}">
+					<f:checkbox name="nonAdministerUsing" />
+				</f:entry>
 				<f:block>
 					<f:entry title="${File}">
 						<!-- @size is for other browsers, @style is for IE -->

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/scriptsettings.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/scriptsettings.properties
@@ -26,3 +26,4 @@ intro=\
   Use the ''println'' command to see the output (if you use <tt>System.out</tt>, \
   it will go to the server''s stdout, which is harder to see.). If you think your script might be useful to others too, please share it on <a target="_blank" href="http://scriptlerweb.appspot.com">scriptler web</a>.
 uploadtext=Select a Groovy script from your local system to be uploaded (*.groovy). 
+Permission = Enable to user with overall permission read

--- a/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/sidepanel.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/scriptler/ScriptlerManagment/sidepanel.jelly
@@ -29,13 +29,13 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/setting.gif" href="${rootURL}/manage" title="${%Manage Hudson}" />
+      <l:task icon="images/24x24/setting.gif" href="${rootURL}/manage" title="${%Manage Hudson}" permission="${app.ADMINISTER}" />
       <l:task icon="images/24x24/next.gif" href="${rootURL}/scriptler" title="${%Run/Edit Scripts}" />
-      <l:task icon="images/24x24/new-package.gif" href="scriptsettings" title="${%Add a new Script}" />
+      <l:task icon="images/24x24/new-package.gif" href="scriptsettings" title="${%Add a new Script}" permission="${app.ADMINISTER}" />
       <j:if test="${!it.disableRemoteCatalog()}">
-      		<l:task icon="images/24x24/folder.gif" href="catalog" title="${%Remote Script catalogs}" />
+      		<l:task icon="images/24x24/folder.gif" href="catalog" title="${%Remote Script catalogs}" permission="${app.ADMINISTER}" />
       </j:if>
-      <l:task icon="images/24x24/setting.gif" href="settings" title="${%Scriptler settings}" />
+      <l:task icon="images/24x24/setting.gif" href="settings" title="${%Scriptler settings}" permission="${app.ADMINISTER}" />
     </l:tasks>
     <t:executors computers="${h.singletonList(it)}" />
   </l:side-panel>


### PR DESCRIPTION
I need to enable users (who does not have ADMINISTER permission) use some scripts. 
I add nonAdministerUsing attribut to Script class. This attribut determines whether the user (with overall permission READ) can use the script. 
User with ADMINISTER permission can set whether the users (with permission READ) can use the script or not. Users can only run this "scripts for user" - no add, edit or delete.
