### PR TITLE
fix JENKINS-16047

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/GroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/GroovyScript.java
@@ -4,6 +4,7 @@ import groovy.lang.GroovyShell;
 import hudson.model.TaskListener;
 import hudson.remoting.DelegatingCallable;
 
+import java.io.PrintStream;
 import java.io.PrintWriter;
 
 import jenkins.model.Jenkins;
@@ -41,22 +42,22 @@ public class GroovyScript implements DelegatingCallable<Object, RuntimeException
         if (cl == null) {
             cl = Thread.currentThread().getContextClassLoader();
         }
-        PrintWriter pw = new PrintWriter(listener.getLogger());
+        PrintStream logger = listener.getLogger();
         GroovyShell shell = new GroovyShell(cl);
 
         for (Parameter param : parameters) {
             final String paramName = param.getName();
             if (PW_PARAM_VARIABLE.equals(paramName)) {
-                pw.write(Messages.skipParamter(PW_PARAM_VARIABLE));
+                logger.println(Messages.skipParamter(PW_PARAM_VARIABLE));
             } else {
                 shell.setVariable(paramName, param.getValue());
             }
         }
-        shell.setVariable(PW_PARAM_VARIABLE, listener.getLogger());
+        shell.setVariable(PW_PARAM_VARIABLE, logger);
         try {
             Object output = shell.evaluate(script);
             if (output != null) {
-                pw.println(Messages.resultPrefix() + " " + output);
+                logger.println(Messages.resultPrefix() + " " + output);
                 return output;
             } else {
                 return "";
@@ -65,7 +66,7 @@ public class GroovyScript implements DelegatingCallable<Object, RuntimeException
             if (failWithException) {
                 throw new ScriptlerExecutionException(t);
             }
-            t.printStackTrace(pw);
+            t.printStackTrace(logger);
             return Boolean.FALSE;
         }
     }


### PR DESCRIPTION
wrapping ByteArrayOutputStream > StreamTaskListener > PrintStream into a PrintWritter seems to introduce some flushing issue that prevent the stacktrace to be dump on syntax error in scriptler
as PrintStream API is fine from GroovyScript simplest fix is to avoid this N-th level wrapper
