### PR TITLE
Add possibility to choose which right the user needs for run user script...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagment.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagment.java
@@ -32,6 +32,7 @@ import hudson.model.ComputerSet;
 import hudson.model.Hudson;
 import hudson.security.Permission;
 
+import hudson.security.PermissionGroup;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -82,7 +83,7 @@ public class ScriptlerManagment extends ManagementLink implements RootAction {
     }
 
     public Permission getRequiredPermissionForRunScript() {
-        return isRunScriptPermissionEnabled() ? Jenkins.RUN_SCRIPTS : Jenkins.ADMINISTER;
+        return isRunScriptPermissionEnabled() ? getConfiguration().getPermissionForUserScripts() : Jenkins.ADMINISTER;
     }
 
     /*
@@ -156,7 +157,7 @@ public class ScriptlerManagment extends ManagementLink implements RootAction {
      * @throws IOException
      */
     public HttpResponse doScriptlerSettings(StaplerRequest res, StaplerResponse rsp, @QueryParameter("disableRemoteCatalog") boolean disableRemoteCatalog,
-            @QueryParameter("allowRunScriptPermission") boolean allowRunScriptPermission, @QueryParameter("allowRunScriptEdit") boolean allowRunScriptEdit)
+            @QueryParameter("allowRunScriptPermission") boolean allowRunScriptPermission, @QueryParameter("allowRunScriptEdit") boolean allowRunScriptEdit, @QueryParameter("permissionId") String permissionId)
             throws IOException {
         checkPermission(Hudson.ADMINISTER);
 
@@ -164,8 +165,8 @@ public class ScriptlerManagment extends ManagementLink implements RootAction {
         cfg.setDisbableRemoteCatalog(disableRemoteCatalog);
         cfg.setAllowRunScriptEdit(allowRunScriptEdit);
         cfg.setAllowRunScriptPermission(allowRunScriptPermission);
+        cfg.setPermissionForUserScripts(permissionId);
         cfg.save();
-
         return new HttpRedirect("settings");
     }
 
@@ -588,5 +589,13 @@ public class ScriptlerManagment extends ManagementLink implements RootAction {
         name = name.replace(" ", "_").trim();
         LOGGER.fine("set file name to: " + name);
         return name;
+    }
+    
+    public List<Permission> getAllPermissions(){
+        List<Permission> permissions = new ArrayList<Permission>();
+        for(PermissionGroup group :PermissionGroup.getAll()){
+            permissions.addAll(group.getPermissions());
+        }
+        return permissions;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
@@ -43,6 +43,8 @@ import org.jenkinsci.plugins.scriptler.share.CatalogInfo;
 import org.jenkinsci.plugins.scriptler.util.ByIdSorter;
 
 import com.thoughtworks.xstream.XStream;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 
 /**
  */
@@ -59,6 +61,8 @@ public final class ScriptlerConfiguration extends ScriptSet implements Saveable 
     private boolean allowRunScriptPermission = false;
 
     private boolean allowRunScriptEdit = false;
+    
+    private String permissionForUserScripts = Jenkins.RUN_SCRIPTS.getId();
 
     public ScriptlerConfiguration(SortedSet<Script> scripts) {
         if (scripts != null) {
@@ -130,6 +134,14 @@ public final class ScriptlerConfiguration extends ScriptSet implements Saveable 
 
     public void setAllowRunScriptPermission(boolean allowRunScriptPermission) {
         this.allowRunScriptPermission = allowRunScriptPermission;
+    }
+    
+    public void setPermissionForUserScripts(String permissionId){
+        permissionForUserScripts = permissionId;
+    }
+    
+    public Permission getPermissionForUserScripts(){
+        return Permission.fromId(permissionForUserScripts);
     }
 
     public boolean isAllowRunScriptEdit() {

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagment/settings.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagment/settings.jelly
@@ -41,9 +41,16 @@
 					<f:entry title="${%Disable remote catalog}" help="/plugin/scriptler/help-disableRemoterCatalog.html">
 						<f:checkbox name="disableRemoteCatalog" checked="${it.disableRemoteCatalog()}" />
 					</f:entry>
-                    <f:entry title="${%Allow RunScript permission}" help="/plugin/scriptler/help-allowRunScriptPermission.html">
-                        <f:checkbox name="allowRunScriptPermission" checked="${it.allowRunScriptPermission()}" />
-                    </f:entry>
+                    <f:optionalBlock title="${%Allow RunScript permission}" help="/plugin/scriptler/help-allowRunScriptPermission.html" name="allowRunScriptPermission" checked="${it.allowRunScriptPermission()}" >                       
+                         <tr><td></td>
+                         <td>
+                           <select name="permissionId">
+                             <j:forEach var="permission" items="${it.getAllPermissions()}">
+                              <f:option value="${permission.getId()}" selected="${permission.getId().equals(it.getConfiguration().getPermissionForUserScripts().getId())}">${permission.group.title}: ${permission.name}</f:option>
+                             </j:forEach>               
+                           </select> 
+                        </td></tr>
+                    </f:optionalBlock>
                     <f:entry title="${%Allow RunScript editing}" help="/plugin/scriptler/help-allowRunScriptEdit.html">
                         <f:checkbox name="allowRunScriptEdit" checked="${it.allowRunScriptEdit()}" />
                     </f:entry>


### PR DESCRIPTION
Hi, I added to possibility to choose which permission users need to run user scripts. I want to use Scriptler plugin for adding to users part of functionality, which is under permission, which they do not have, by scripts. RUN_SCRIPT is permission which is need for Script console on Jenkins - so the users can do what ever they want with this permission. I want to have user scripts in Scriptler under another permission, so let administer user choose which permission is needed for user scripts.
