### PR TITLE
Add BuildWrapper extension for

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/buildwrapper/ScriptlerBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/buildwrapper/ScriptlerBuildWrapper.java
@@ -1,0 +1,268 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.jenkinsci.plugins.scriptler.buildwrapper;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Project;
+import hudson.security.Permission;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletException;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.scriptler.Messages;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagment;
+import org.jenkinsci.plugins.scriptler.config.Parameter;
+import org.jenkinsci.plugins.scriptler.config.Script;
+import org.jenkinsci.plugins.scriptler.config.ScriptlerConfiguration;
+import org.jenkinsci.plugins.scriptler.util.GroovyScript;
+import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
+import org.jenkinsci.plugins.scriptler.util.UIHelper;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
+
+/**
+ *
+ * @author stuartr
+ */
+public class ScriptlerBuildWrapper extends BuildWrapper {
+    
+    private final static Logger LOGGER = Logger.getLogger(ScriptlerBuildWrapper.class.getName());
+    
+    private String buildWrapperId;
+    private String scriptId;
+    private boolean propagateParams = true;
+    private Parameter[] parameters;
+    
+    public ScriptlerBuildWrapper(String buildWrapperId, String scriptId, boolean propagateParams, Parameter[] parameters) {
+        this.buildWrapperId = buildWrapperId;
+        this.scriptId = scriptId;
+        this.propagateParams = propagateParams;
+        this.parameters = parameters;
+    }
+
+    public String getScriptId() {
+        return scriptId;
+    }
+
+    public Parameter[] getParameters() {
+        return parameters;
+    }
+    
+    public String getBuildWrapperId() {
+        return buildWrapperId;
+    }
+
+    public boolean isPropagateParams() {
+        return propagateParams;
+    }
+    
+    @Override
+    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+        
+        Map<String,String> injectedEnvVars = null;        
+        boolean isOk = false;
+        final Script script = ScriptHelper.getScript(scriptId, true);
+        
+        if (script != null) {
+            try {
+        
+                // expand the parameters before passing these to the execution, this is to allow any token macro to resolve parameter values
+                List<Parameter> expandedParams = new LinkedList<Parameter>();
+
+                if (propagateParams) {
+                    final ParametersAction paramsAction = build.getAction(ParametersAction.class);
+                    if (paramsAction == null) {
+                        listener.getLogger().println(Messages.no_parameters_defined());
+                    } else {
+                        final List<ParameterValue> jobParams = paramsAction.getParameters();
+                        for (ParameterValue parameterValue : jobParams) {
+                            // pass the params to the token expander in a way that these get expanded by environment variables (params are also environment variables)
+                            expandedParams.add(new Parameter(parameterValue.getName(), TokenMacro.expandAll(build, listener, "${" + parameterValue.getName() + "}", false, null)));
+                        }
+                    }
+                }
+                for (Parameter parameter : parameters) {
+                    expandedParams.add(new Parameter(parameter.getName(), TokenMacro.expandAll(build, listener, parameter.getValue())));
+                }
+                final Object output;
+                if (script.onlyMaster) {
+                    // When run on master, make build, launcher, listener available to script
+                    output = Jenkins.MasterComputer.localChannel.call(new GroovyScript(script.script, expandedParams.toArray(new Parameter[expandedParams.size()]), true, listener, launcher, build));
+                } else {
+                    output = launcher.getChannel().call(new GroovyScript(script.script, expandedParams.toArray(new Parameter[expandedParams.size()]), true, listener));
+                }
+                if (output instanceof Map) {
+                    injectedEnvVars = (Map<String,String>) output;
+                    isOk = true;
+                } else {
+                    isOk = false;
+                }
+            } catch (Exception e) {
+                listener.getLogger().print(Messages.scriptExecutionFailed(scriptId) + " - " + e.getMessage());
+                e.printStackTrace(listener.getLogger());
+            }
+        } else {
+            if (StringUtils.isBlank(scriptId)) {
+                listener.getLogger().print(Messages.scriptNotDefined());
+            } else {
+                listener.getLogger().print(Messages.scriptNotFound(scriptId));
+            }
+        }
+        
+        if(isOk) {
+            return new ScriptlerBuildWrapperEnvironment(injectedEnvVars);
+        }
+        
+        return null;
+    }
+    
+    public class ScriptlerBuildWrapperEnvironment extends Environment {
+
+        private Map<String,String> injectedEnvVars;
+        
+        public ScriptlerBuildWrapperEnvironment(Map<String,String> envVars) {
+            this.injectedEnvVars = envVars;
+        }
+
+        @Override
+        public void buildEnvVars(Map<String, String> env) {
+            // inject parameters into build environment
+            env.putAll(this.injectedEnvVars);
+        }
+    }
+
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+
+        private static final AtomicInteger CURRENT_ID = new AtomicInteger();
+        
+        public boolean isApplicable(AbstractProject<?, ?> item) {
+            // Indicates that this builder can be used with all kinds of project types 
+            return true;
+        }
+
+        /**
+         * This human readable name is used in the configuration screen.
+         */
+        public String getDisplayName() {
+            return Messages.buildWrapper_name();
+        }
+        
+        public Permission getRequiredPermission() {
+            return getScriptler().getRequiredPermissionForRunScript();
+        }
+        
+        @Override
+        public ScriptlerBuildWrapper newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            ScriptlerBuildWrapper buildWrapper = null;
+            String buildWrapperId = formData.optString("buildWrapperId");
+            
+            if (!Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)) {
+                // the user has no permission to change the builders, therefore we reload the builder without his changes!
+                final String backupJobName = formData.optString("backupJobName");
+
+                if (StringUtils.isNotBlank(buildWrapperId) && StringUtils.isNotBlank(backupJobName)) {
+                    final Project<?, ?> project = Jenkins.getInstance().getItemByFullName(backupJobName, Project.class);
+                    final Map<Descriptor<BuildWrapper>,BuildWrapper> buildWrappers = project.getBuildWrappers();
+                    for (BuildWrapper b : buildWrappers.values()) {
+                        if (b instanceof ScriptlerBuildWrapper) {
+                            ScriptlerBuildWrapper sb = (ScriptlerBuildWrapper) b;
+                            if (buildWrapperId.equals(sb.getBuildWrapperId())) {
+                                LOGGER.log(Level.FINE, "reloading ScriptlerBuilder [" + buildWrapperId + "] on project [" + backupJobName + "], as user has no permission to change it!");
+                                return sb;
+                            }
+                        }
+                    }
+                }
+
+            } else {
+                final String id = formData.optString("scriptlerScriptId");
+                final boolean inPropagateParams = formData.getBoolean("propagateParams");
+                if (StringUtils.isBlank(buildWrapperId)) {
+                    // create a unique id - this is only used to identify the builder if a user without privileges modifies the job.
+                    buildWrapperId = System.currentTimeMillis() + "_" + CURRENT_ID.addAndGet(1);
+                }
+                if (StringUtils.isNotBlank(id)) {
+                    Parameter[] params = null;
+                    try {
+                        params = UIHelper.extractParameters(formData);
+                    } catch (ServletException e) {
+                        throw new FormException(Messages.parameterExtractionFailed(), "parameters");
+                    }
+                    buildWrapper = new ScriptlerBuildWrapper(buildWrapperId, id, inPropagateParams, params);
+                }
+            }
+            if (buildWrapper == null) {
+                buildWrapper = new ScriptlerBuildWrapper(buildWrapperId, null, false, null);
+            }
+            return buildWrapper;
+        }
+        
+        public Set<Script> getScripts() {
+            // TODO currently only script for RUN_SCRIPT permissions are returned?
+            final Set<Script> scripts = getConfig().getScripts();
+            final Set<Script> scriptsForBuilder = new HashSet<Script>();
+            for (Script script : scripts) {
+                if (script.nonAdministerUsing) {
+                    scriptsForBuilder.add(script);
+                }
+            }
+            return scriptsForBuilder;
+        }
+
+        private ScriptlerManagment getScriptler() {
+            return Jenkins.getInstance().getExtensionList(ScriptlerManagment.class).get(0);
+        }
+
+        private ScriptlerConfiguration getConfig() {
+            return getScriptler().getConfiguration();
+        }
+
+        /**
+         * gets the argument description to be displayed on the screen when selecting a config in the dropdown
+         * 
+         * @param configId
+         *            the config id to get the arguments description for
+         * @return the description
+         */
+        @JavaScriptMethod
+        public JSONArray getParameters(String scriptlerScriptId) {
+            final Script script = getConfig().getScriptById(scriptlerScriptId);
+            if (script != null && script.getParameters() != null) {
+                return JSONArray.fromObject(script.getParameters());
+            }
+            return null;
+        }
+    }
+    
+}

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/Messages.properties
@@ -30,6 +30,7 @@ node_not_found=The node [{0}] could not be found!
 node_not_online=The selected node [{0}] is not online, therefore the script can not be executed! Select an other node or start it before you try again.
 download_failed=The import of the script [{0}] from catalog [{1}] failed.
 builder_name=Scriptler script
+buildWrapper_name=Inject environment variables with Scriptler script
 scriptNotFound = could not find script with id [{0}]
 scriptNotDefined = there is no script for scriptler defined, please fix your configuration! 
 scriptExecutionFailed = Execution of script [{0}] failed

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/buildwrapper/ScriptlerBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/buildwrapper/ScriptlerBuildWrapper/config.jelly
@@ -1,0 +1,87 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype" includes="org.kohsuke.stapler.bind"/>
+    <st:once>
+        <script type="text/javascript" src="${rootURL}/plugin/scriptler/lib/scriptler.js" />
+    </st:once>
+    <j:choose>
+        <j:when test="${empty(descriptor.scripts)}">
+            <f:entry title="">
+                <div>
+                    ${%WarnNoScript} <a href="${rootURL}/scriptler">scriptler</a>
+                </div>
+            </f:entry>
+        </j:when>
+        <j:otherwise>
+            <j:if test="${!h.hasPermission(it.build,descriptor.requiredPermission)}">
+                <div class="warning">${%NoPermission}</div>
+            </j:if>
+            <f:entry title="${%Script}">
+                <input type="hidden" name="backupJobName" />    
+                <input type="hidden" name="buildWrapperId" value="${instance.buildWrapperId}" />
+                <f:entry field="scriptId">            
+                    <select name="scriptlerScriptId" onChange="scriptler_initDetailLink('${rootURL}', this);scriptler_showParams(this, this.value);" >
+                        <option value="">(Default)</option>
+                        <j:forEach var="inst" items="${descriptor.scripts}" varStatus="loop">
+                            <j:choose>
+                                <j:when test="${inst.id == instance.scriptId}">
+                                    <option value="${inst.id}" selected="selected">${inst.name}</option>
+                                </j:when>
+                                <j:otherwise>
+                                    <option value="${inst.id}">${inst.name}</option>
+                                </j:otherwise>
+                            </j:choose>
+                        </j:forEach>
+                    </select>
+                </f:entry>
+                <a target="_blank" name="showScriptlerDetailLink" href="" style="display:none;" onclick="window.open(this.href,'window','width=900,height=640,resizable,scrollbars,toolbar,menubar') ;return false;"> ${%ViewScript}</a>
+                <div id="scriptlerDescription">${%RequiredParameters} <div name="scriptlerParameters" /></div>
+                <f:block>
+                    <f:entry title="${%PropagateParams}" field="propagateParams" help="/plugin/scriptler/help-propagateParams.html">
+                        <f:checkbox checked="${instance.isPropagateParams()}" />
+                    </f:entry>
+                </f:block>				
+                <f:block>
+                    <table>
+                        <f:optionalBlock name="defineParams" title="${%ParametersDescription}" checked="${!empty(instance.parameters)}" help="/plugin/scriptler/help-params.html">
+                            <f:entry title="${%Parameters}" field="parameters">
+                                <f:repeatable var="param" items="${instance.parameters}" name="parameters" noAddButton="true" minimum="1">
+                                    <table width="100%">
+                                        <f:entry>
+                                            ${%ParameterName} <input type="text" name="name" value="${param.name}" size="50"/>
+                                            ${%ParameterValue} <input type="text" name="value" value="${param.value}" size="80"/>
+                                            <input type="button" name="delete_button" value="${%DeleteParameter}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
+                                            <input type="button" name="add_button" value="${%AddParameter}" class="repeatable-add show-if-last" />
+                                        </f:entry>
+                                    </table>
+                                </f:repeatable>
+                            </f:entry>
+                        </f:optionalBlock>						
+                    </table>
+                </f:block>
+            </f:entry>
+        </j:otherwise>
+    </j:choose>
+    <st:bind var="scriptlerBuilderDesc" value="${descriptor}"/>
+    <st:once>
+        <script type="text/javascript">
+            Event.observe(window, 'load', function() { 
+            var all = new Array();
+            all = document.getElementsByName('scriptlerScriptId');
+            for(var i = 0; i &lt; all.length; i++) {
+            all.item(i).disabled=<j:out value="${!h.hasPermission(it.build,descriptor.requiredPermission)}" />;
+            scriptler_initDetailLink('<j:out value="${rootURL}" />', all.item(i));
+            scriptler_showParams(all.item(i), all.item(i).value);
+            }
+				
+            // remember the job name to send it along with the form
+            var jobName = document.getElementsByName('name').item(0).value;
+            var allBackupJobNames = document.getElementsByName('backupJobName');
+            for(var i = 0; i &lt; allBackupJobNames.length; i++) {
+            allBackupJobNames.item(i).value = jobName; 
+            } 
+				
+            });
+        </script>
+    </st:once>
+</j:jelly>


### PR DESCRIPTION
Allows for scriptler scripts that return maps of string key/value pairs
to inject environment variables for a build

Scripts are configured and executed in the same way they are handled by
the Builder extension
