### PR TITLE
Increase width to let space for the optional 5th script action icon

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagment/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagment/index.jelly
@@ -40,7 +40,7 @@
 					</j:choose>
 					<j:forEach var="t" items="${items}">
 						<tr valign="center" style="border-top: 0px;">
-							<td class="pane" width="86">
+							<td class="pane" width="104">
 								<j:choose>
 									<j:when test="${t.available == false}">
 										<img width="16" height="16" title="${%fileNotAvailable}" src="${imagesURL}/16x16/red.gif" />


### PR DESCRIPTION
Before:
![screen shot 2015-02-23 at 14 33 52](https://cloud.githubusercontent.com/assets/24282/6328618/9d77fc60-bb69-11e4-970a-392a8cb7e685.png)
![screen shot 2015-02-23 at 14 33 59](https://cloud.githubusercontent.com/assets/24282/6328619/9d79d72e-bb69-11e4-93bc-b31c4136a0f1.png)

After:
![screen shot 2015-02-23 at 14 34 26](https://cloud.githubusercontent.com/assets/24282/6328620/9d7aea2e-bb69-11e4-81fb-6ae0f56a5faf.png)
![screen shot 2015-02-23 at 14 34 33](https://cloud.githubusercontent.com/assets/24282/6328621/9d7bfaea-bb69-11e4-994b-38286e32ef71.png)
