### PR TITLE
Upon uploading a script, its parameter list is not set, causing a NPE…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
@@ -60,7 +60,7 @@ public class Script implements Comparable<Script>, NamedResource {
      * used during plugin start to synchronize available scripts
      */
     public Script(String id, String comment, boolean available, boolean nonAdministerUsing, boolean onlyMaster) {
-        this(id, id, comment, null, null, null, nonAdministerUsing, null, false);
+        this(id, id, comment, null, null, null, nonAdministerUsing, new Parameter[0], onlyMaster);
     }
 
     /**


### PR DESCRIPTION
… when running it using the REST end point.

1. Upload a script
2. Run it from the command line using a Curl command

The root cause is that the parameter list is not set (or set to `null`) when uploading a script.