### PR TITLE
Escape textarea in view "Edit" and "Run"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
@@ -464,6 +464,7 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
             // the output.
             tempScript = ScriptHelper.getScriptCopy(id, false);
             tempScript.setScript(scriptSrc);
+            tempScript.computeTextAreaEscaped();
         }
 
         final String[] slaves = resolveSlaveNames(node);

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
@@ -42,6 +42,11 @@ public class Script implements Comparable<Script>, NamedResource {
      */
     public transient String script;
 
+    /**
+     * same as script, with textarea escaped, when displayed in a textarea
+     */
+    public transient String scriptTextAreaEscaped;
+    
     // for user with RUN_SCRIPT permission
     public final boolean nonAdministerUsing;
 
@@ -117,7 +122,14 @@ public class Script implements Comparable<Script>, NamedResource {
     public void setScript(String script) {
         this.script = script;
     }
-
+    
+    /**
+     * used to escape textarea when script is displayed in a textarea
+     */
+    public void computeTextAreaEscaped() {
+    	if(script!=null)this.scriptTextAreaEscaped = script.replaceAll("</textarea", "&lt;/textarea");
+    }
+    
     public void setParameters(Parameter[] parameters) {
         this.parameters = parameters;
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
@@ -73,6 +73,7 @@ public class ScriptHelper {
                 Reader reader = new FileReader(scriptSrc);
                 String src = IOUtils.toString(reader);
                 s.setScript(src);
+                s.computeTextAreaEscaped();
             } catch (IOException e) {
                 LOGGER.log(Level.SEVERE, Messages.scriptSourceNotFound(id), e);
             }

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/edit.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/edit.jelly
@@ -72,7 +72,7 @@ THE SOFTWARE.
 	                </f:block>					
 					<f:entry title="${%Script}">
 						<textarea id="script" name="script" class="script">
-							<j:out value="${script.script}" />
+							<j:out value="${script.scriptTextAreaEscaped}" />
 						</textarea>
 					</f:entry>
 				</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runscript.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runscript.jelly
@@ -96,7 +96,7 @@ THE SOFTWARE.
 				</table>
 
 				<textarea id="script" name="script" class="script" script-readOnly="${readOnly}">
-					<j:out value="${script.script}" />
+					<j:out value="${script.scriptTextAreaEscaped}" />
 				</textarea>
 				<div align="right">
 					<f:submit value="${%Run}" />


### PR DESCRIPTION
Hello,
I made this update in order to correct a bug when editing script in view "Edit" and "Run".
The bug is that when there is a closing textarea tag in the groovy script, this tag is not escaped and the script isn't correcty rendered in the textarea for editing.
You can see the bug in this screenshoot :

![before](https://cloud.githubusercontent.com/assets/23095698/20014333/e5828a12-a2b6-11e6-99d8-8347ba51525d.PNG)

So I made a small modif, adding a new member variable to class Script, which is get back by views "Edit" and "Run".
And I added a function that compute this field from the script field, and the call of this function in ScriptlerManagement and Scriptlerhelper.

This is the result : 

![after](https://cloud.githubusercontent.com/assets/23095698/20014596/e9bc22b8-a2b7-11e6-8052-08ef8c489fd2.PNG)

