### PR TITLE
[SECURITY-366] Scripts cannot be added by name anymore

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -240,7 +240,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
 
         /**
          * gets the argument description to be displayed on the screen when selecting a config in the dropdown
-         *
+         * 
          * @param configId
          *            the config id to get the arguments description for
          * @return the description

--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -59,6 +59,21 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         this.scriptId = scriptId;
         this.parameters = parameters;
         this.propagateParams = propagateParams;
+
+        this.readResolve();
+    }
+
+    private Object readResolve() {
+        Script script = ScriptHelper.getScript(scriptId, true);
+
+        if (script != null) {
+            if (!script.nonAdministerUsing) {
+                this.scriptId = null;
+                throw new IllegalArgumentException("The script is not allowed to be executed in a build, check its configuration!");
+            }
+        }
+
+        return this;
     }
 
     public String getScriptId() {
@@ -225,7 +240,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
 
         /**
          * gets the argument description to be displayed on the screen when selecting a config in the dropdown
-         * 
+         *
          * @param configId
          *            the config id to get the arguments description for
          * @return the description

--- a/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
@@ -107,6 +107,7 @@ public class ScriptlerBuilderTest {
     }
 
     @Test
+    @Issue("SECURITY-366")
     public void scriptNotUsableByNonAdmin_isNotInjectableBy_configXml() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setCrumbIssuer(null);

--- a/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
@@ -1,0 +1,150 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.scriptler.builder;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import hudson.model.FileParameterValue;
+import hudson.model.FreeStyleProject;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagementHelper;
+import org.jenkinsci.plugins.scriptler.config.Parameter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ScriptlerBuilderTest {
+
+    private static final String SCRIPT_USABLE_1 = "usable_1.groovy";
+    private static final String SCRIPT_USABLE_2 = "usable_2.groovy";
+    private static final String SCRIPT_NOT_USABLE = "not_usable.groovy";
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void configureScripts() throws Exception {
+        ScriptlerManagement scriptler = j.getInstance().getExtensionList(ScriptlerManagement.class).get(0);
+        ScriptlerManagementHelper helper = new ScriptlerManagementHelper(scriptler);
+
+        File f1 = new File(SCRIPT_USABLE_1);
+        FileUtils.writeStringToFile(f1, "print 'test1'");
+        FileItem fi1 = new FileParameterValue.FileItemImpl(f1);
+        helper.saveScript(fi1, true, SCRIPT_USABLE_1);
+        f1.delete();
+
+        File f2 = new File(SCRIPT_USABLE_2);
+        FileUtils.writeStringToFile(f2, "print 'test2'");
+        FileItem fi2 = new FileParameterValue.FileItemImpl(f2);
+        helper.saveScript(fi2, true, SCRIPT_USABLE_2);
+        f2.delete();
+
+        File f3 = new File(SCRIPT_NOT_USABLE);
+        FileUtils.writeStringToFile(f3, "print 'test3'");
+        FileItem fi3 = new FileParameterValue.FileItemImpl(f3);
+        helper.saveScript(fi3, false, SCRIPT_NOT_USABLE);
+        f3.delete();
+    }
+
+    @Test
+    public void scriptNotUsableByNonAdmin_isNotInjectableBy_configSubmit() throws Exception {
+        // use the same flow as a call to submit in the config page
+
+        FreeStyleProject projectOk = j.createFreeStyleProject("testOk");
+        projectOk.getBuildersList().add(new ScriptlerBuilder("random-id1", SCRIPT_USABLE_1, false, new Parameter[0]));
+
+        assertNotEquals(projectOk.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_NOT_USABLE);
+        projectOk = j.jenkins.getItemByFullName(projectOk.getFullName(), FreeStyleProject.class);
+        assertNotEquals(projectOk.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_NOT_USABLE);
+
+        FreeStyleProject projectNotOk = j.createFreeStyleProject("testNotOk");
+        try {
+            projectNotOk.getBuildersList().add(new ScriptlerBuilder("random-id2", SCRIPT_NOT_USABLE, false, new Parameter[0]));
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("The script is not allowed to be executed in a build, check its configuration!", e.getMessage());
+        }
+
+        assertTrue(projectNotOk.getBuildersList().isEmpty());
+        projectNotOk = j.jenkins.getItemByFullName(projectNotOk.getFullName(), FreeStyleProject.class);
+        assertTrue(projectNotOk.getBuildersList().isEmpty());
+    }
+
+    @Test
+    public void scriptNotUsableByNonAdmin_isNotInjectableBy_configXml() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setCrumbIssuer(null);
+
+        FreeStyleProject project = j.createFreeStyleProject("test");
+        project.getBuildersList().add(new ScriptlerBuilder("random-id", SCRIPT_USABLE_1, false, new Parameter[0]));
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        assertEquals(project.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_USABLE_1);
+
+        XmlPage xmlPage = wc.goToXml(project.getShortUrl() + "config.xml");
+        j.assertGoodStatus(xmlPage);
+        String xml = xmlPage.getWebResponse().getContentAsString();
+        String modifiedXml = xml.replace("<scriptId>" + SCRIPT_USABLE_1 + "</scriptId>", "<scriptId>" + SCRIPT_USABLE_2 + "</scriptId>");
+
+        WebRequest request = new WebRequest(new URL(project.getAbsoluteUrl() + "config.xml"), HttpMethod.POST);
+        request.setRequestBody(modifiedXml);
+        request.setEncodingType(null);
+        HtmlPage p = wc.getPage(request);
+        j.assertGoodStatus(p);
+
+        assertEquals(project.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_USABLE_2);
+        project = j.jenkins.getItemByFullName(project.getFullName(), FreeStyleProject.class);
+        assertEquals(project.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_USABLE_2);
+
+        XmlPage xmlPage2 = wc.goToXml(project.getShortUrl() + "config.xml");
+        j.assertGoodStatus(xmlPage2);
+        String xml2 = xmlPage2.getWebResponse().getContentAsString();
+        String modifiedXml2 = xml2.replace("<scriptId>" + SCRIPT_USABLE_2 + "</scriptId>", "<scriptId>" + SCRIPT_NOT_USABLE + "</scriptId>");
+
+        WebRequest request2 = new WebRequest(new URL(project.getAbsoluteUrl() + "config.xml"), HttpMethod.POST);
+        request2.setRequestBody(modifiedXml2);
+        request2.setEncodingType(null);
+        HtmlPage p2 = wc.getPage(request2);
+        // the request is accepted but the invalid config is not applied, since the scriptId is not critical
+        j.assertGoodStatus(p2);
+
+        assertNotEquals(project.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_NOT_USABLE);
+        project = j.jenkins.getItemByFullName(project.getFullName(), FreeStyleProject.class);
+        assertNotEquals(project.getBuildersList().get(ScriptlerBuilder.class).getScriptId(), SCRIPT_NOT_USABLE);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
@@ -37,6 +37,7 @@ import org.jenkinsci.plugins.scriptler.config.Parameter;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
@@ -81,6 +82,7 @@ public class ScriptlerBuilderTest {
     }
 
     @Test
+    @Issue("SECURITY-366")
     public void scriptNotUsableByNonAdmin_isNotInjectableBy_configSubmit() throws Exception {
         // use the same flow as a call to submit in the config page
 


### PR DESCRIPTION
- the execution protection was done by [d1986c8814](https://github.com/jenkinsci/scriptler-plugin/commit/d1986c8814824b461bce4e51293776ed99721de9)
- avoid modifying a script id to one that is not runnable using config.xml or configSubmit

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Verifiy the submitted script id is executable by non-administer whatever means is used to send data (using REST or form)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @oleg-nenashev @imod 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
