### PR TITLE
Allow view to be used in test

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder/config.jelly
@@ -3,7 +3,7 @@
 
     <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype" includes="org.kohsuke.stapler.bind"/>
 	<st:once>
-		<script type="text/javascript" src="${rootURL}/plugin/scriptler/lib/scriptler.js" />
+		<script type="text/javascript" src="${resURL}/plugin/scriptler/lib/scriptler.js" />
 	</st:once>
 	<j:choose>
 		<j:when test="${empty(descriptor.scripts)}">


### PR DESCRIPTION
- because of the `${rootURL}`, when we are unit-testing the project configuration page, we receive a 404 error cause by the scriptler.js that is not found. When running the application normally I did not encounter this issue, only when testing. So I replace it with `${resURL}`, like explained in the [wiki](https://wiki.jenkins.io/display/JENKINS/Hyperlinks+in+HTML).

@reviewbybees 