### PR TITLE
Sort the scripts by name for the views

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -11,7 +11,8 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -203,15 +204,16 @@ public class ScriptlerBuilder extends Builder implements Serializable {
             return builder;
         }
 
-        public Set<Script> getScripts() {
+        public List<Script> getScripts() {
             // TODO currently only script for RUN_SCRIPT permissions are returned?
-            final Set<Script> scripts = getConfig().getScripts();
-            final Set<Script> scriptsForBuilder = new HashSet<Script>();
+            Set<Script> scripts = getConfig().getScripts();
+            List<Script> scriptsForBuilder = new ArrayList<Script>();
             for (Script script : scripts) {
                 if (script.nonAdministerUsing) {
                     scriptsForBuilder.add(script);
                 }
             }
+            Collections.sort(scriptsForBuilder, Script.COMPARATOR_BY_NAME);
             return scriptsForBuilder;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
@@ -25,6 +25,8 @@ package org.jenkinsci.plugins.scriptler.config;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.Comparator;
+
 public class Script implements Comparable<Script>, NamedResource {
 
     private String id;
@@ -192,4 +194,11 @@ public class Script implements Comparable<Script>, NamedResource {
         return true;
     }
 
+    public static Comparator<Script> COMPARATOR_BY_NAME = new Comparator<Script>() {
+        @Override public int compare(Script a, Script b) {
+            String nameA = a.getName() != null ? a.getName() : "";
+            String nameB = b.getName() != null ? b.getName() : "";
+            return nameA.compareToIgnoreCase(nameB);
+        }
+    };
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
@@ -35,6 +35,7 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
 import org.jenkinsci.plugins.scriptler.share.CatalogInfo;
 import org.jenkinsci.plugins.scriptler.util.ByIdSorter;
@@ -135,5 +136,19 @@ public final class ScriptlerConfiguration extends ScriptSet implements Saveable 
 
     public boolean isAllowRunScriptPermission() {
         return allowRunScriptPermission;
+    }
+
+    // for Jelly view
+    public List<Script> getSortedScripts(){
+        List<Script> sortedScripts;
+        if(Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)){
+            sortedScripts = new ArrayList<Script>(this.getScripts());
+        }else{
+            sortedScripts = new ArrayList<Script>(this.getUserScripts());
+        }
+
+        Collections.sort(sortedScripts, Script.COMPARATOR_BY_NAME);
+
+        return sortedScripts;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/ScriptInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/ScriptInfo.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.scriptler.share;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.jenkinsci.plugins.scriptler.config.NamedResource;
@@ -140,4 +141,11 @@ public class ScriptInfo implements NamedResource {
         }
     }
 
+    public static Comparator<ScriptInfo> COMPARATOR_BY_NAME = new Comparator<ScriptInfo>() {
+        @Override public int compare(ScriptInfo a, ScriptInfo b) {
+            String nameA = a.getName() != null ? a.getName() : "";
+            String nameB = b.getName() != null ? b.getName() : "";
+            return nameA.compareToIgnoreCase(nameB);
+        }
+    };
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/CentralScriptJsonCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/CentralScriptJsonCatalog.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.scriptler.share.gh;
 
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.model.DownloadService.Downloadable;
 
 import java.io.IOException;
@@ -32,4 +33,7 @@ public class CentralScriptJsonCatalog extends Downloadable {
         return (ScriptInfoList) JSONObject.toBean(d, ScriptInfoList.class);
     }
 
+    public static CentralScriptJsonCatalog getCatalog() {
+        return ExtensionList.lookup(CentralScriptJsonCatalog.class).get(CentralScriptJsonCatalog.class);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -16,6 +17,8 @@ import java.util.logging.Logger;
 import org.jenkinsci.plugins.scriptler.share.CatalogInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfoCatalog;
+
+import javax.annotation.CheckForNull;
 
 /**
  * Provides access to the scriptler scripts shared at https://github.com/jenkinsci/jenkins-scripts
@@ -35,12 +38,7 @@ public class GHCatalog extends ScriptInfoCatalog<ScriptInfo> {
 
     @Override
     public List<ScriptInfo> getEntries() {
-        try {
-            return Arrays.asList(CentralScriptJsonCatalog.all().get(CentralScriptJsonCatalog.class).toList().list);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "not abe to load script infos from GH", e);
-        }
-        return Collections.emptyList();
+        return getEntries(ScriptInfo.COMPARATOR_BY_NAME);
     }
 
     @Override
@@ -50,7 +48,7 @@ public class GHCatalog extends ScriptInfoCatalog<ScriptInfo> {
 
     @Override
     public ScriptInfo getEntryById(String id) {
-        for (ScriptInfo info : getEntries()) {
+        for (ScriptInfo info : getEntries(null)) {
             if (id.equals(info.getId())) {
                 return info;
             }
@@ -58,6 +56,21 @@ public class GHCatalog extends ScriptInfoCatalog<ScriptInfo> {
         return null;
     }
 
+    private List<ScriptInfo> getEntries(@CheckForNull Comparator<ScriptInfo> comparator){
+        ScriptInfo[] scriptInfoArray = new ScriptInfo[0];
+        try {
+            scriptInfoArray = CentralScriptJsonCatalog.getCatalog().toList().list;
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "not abe to load script infos from GH", e);
+        }
+        List<ScriptInfo> sortedScriptInfoList = Arrays.asList(scriptInfoArray);
+
+        if(comparator != null)
+            Collections.sort(sortedScriptInfoList, comparator);
+    
+        return sortedScriptInfoList;
+    }
+    
     @Override
     public CatalogInfo getInfo() {
         return CATALOG_INFO;

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/index.jelly
@@ -32,14 +32,7 @@
 					</h3>
 				</j:if>
 				<table class="pane">
-					<j:choose>
-						<j:when test="${h.hasPermission(it,app.ADMINISTER)}">
-							<j:set var="items" value="${it.configuration.scripts}" />
-						</j:when>
-						<j:otherwise>
-							<j:set var="items" value="${it.configuration.UserScripts}" />
-						</j:otherwise>
-					</j:choose>
+					<j:set var="items" value="${it.configuration.sortedScripts}" />
 					<j:forEach var="t" items="${items}">
 						<tr valign="center" style="border-top: 0px;">
 							<td class="pane scriptler-nowrap" width="104">


### PR DESCRIPTION
As it becomes less ergonomic as the number of scripts grows, this PR comes with sorted lists in catalog, in the select in builder step and also in the script configuration view.
- normally there is no impact on the rest of the logic

No associated ticket

@reviewbybees @imod 

<details>
<summary>Screenshot before / after</summary>


## Before:
### Catalog:
![before_catalog](https://user-images.githubusercontent.com/2662497/34851871-4984afa2-f72c-11e7-8197-e17b32c4f8b2.png)
### Config:
![before_config](https://user-images.githubusercontent.com/2662497/34851872-499fd21e-f72c-11e7-8e09-2d9cd6556ec7.png)
### Build step:
![before_step](https://user-images.githubusercontent.com/2662497/34851870-496c9c50-f72c-11e7-8404-94faa4d53b43.png)

## After:
### Catalog:
![after_catalog](https://user-images.githubusercontent.com/2662497/34851859-38bb2dae-f72c-11e7-93f9-d8c73064d158.png)
### Config:
![after_config](https://user-images.githubusercontent.com/2662497/34851860-38e227f6-f72c-11e7-918c-2fdaf9d50a76.png)
### Build step:
![after_step](https://user-images.githubusercontent.com/2662497/34851861-38fe1722-f72c-11e7-9ba1-15954b338fa9.png)

</details>

