### PR TITLE
Close the stream properly to avoid lock when using jenkins ui and git scriptler repo

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
@@ -3,9 +3,11 @@ package org.jenkinsci.plugins.scriptler.util;
 import hudson.model.Computer;
 import hudson.util.StreamTaskListener;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -70,9 +72,9 @@ public class ScriptHelper {
         }
         Script s = ScriptlerConfiguration.getConfiguration().getScriptById(id);
         if (withSrc && s != null) {
-            try {
-                File scriptSrc = new File(ScriptlerManagement.getScriptDirectory(), s.getScriptPath());
-                Reader reader = new InputStreamReader(new FileInputStream(scriptSrc), Charset.forName("UTF-8"));
+            File scriptSrc = new File(ScriptlerManagement.getScriptDirectory(), s.getScriptPath());
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(scriptSrc),
+                            Charset.forName("UTF-8")))) {
                 String src = IOUtils.toString(reader);
                 s.setScript(src);
             } catch (IOException e) {


### PR DESCRIPTION
I had issues when using both scriptler from jenkins ui plugin and git repo. My guess is that when opening the script on server, the stream is not closed and the java process keeps a lock on the file. 
After adding the try with resources, I had no more issues.