### PR TITLE
fix JENKINS-65691 by preventing Jelly from embedding unescaped content into HTML

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/edit.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/edit.jelly
@@ -76,7 +76,7 @@ THE SOFTWARE.
 								${%ScriptNotFound}
 							</j:when>
 							<j:otherwise>
-								<j:out value="${script.script}" />
+								${script.script}
 							</j:otherwise>
 						</j:choose>
 					</textarea>

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runScript.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runScript.jelly
@@ -106,7 +106,7 @@ THE SOFTWARE.
 							${%ScriptNotFound}
 						</j:when>
 						<j:otherwise>
-							<j:out value="${script.script}" />
+							${script.script}
 						</j:otherwise>
 					</j:choose>
 				</textarea>

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/show.jelly
@@ -72,7 +72,7 @@ THE SOFTWARE.
 	                </f:block>					
 					<f:entry title="${%Script}">
 						<textarea id="script" name="script" style="width:100%; height:20em">
-							<j:out value="${script.script}" />
+							${script.script}
 						</textarea>
 					</f:entry>
 				</j:jelly>


### PR DESCRIPTION
This is a quick and straightforward fix of the issue by removing the Jelly constructs that made it output unescaped HTML
inside textarea elements