### PR TITLE
JENKINS-59841: Always use UTF-8 when dealing with files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
@@ -31,7 +31,6 @@ import hudson.model.*;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptler.config.Parameter;
 import org.jenkinsci.plugins.scriptler.config.Script;
@@ -49,7 +48,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -268,7 +266,7 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
             throw new IOException("Invalid file path received: " + id);
         }
 
-        FileUtils.writeStringToFile(newScriptFile, script, StandardCharsets.UTF_8);
+        ScriptHelper.writeScriptToFile(newScriptFile, script);
 
         commitFileToGitRepo(finalFileName);
 
@@ -416,7 +414,7 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
             script = new Script(fixedFileName, fixedFileName, true, nonAdministerUsing, false);
         }
 
-        String scriptSource = FileUtils.readFileToString(f, "UTF-8");
+        String scriptSource = ScriptHelper.readScriptFromFile(f);
         ScriptHelper.putScriptInApprovalQueueIfRequired(scriptSource);
 
         ScriptlerConfiguration config = getConfiguration();

--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerPluginImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerPluginImpl.java
@@ -37,7 +37,6 @@ import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.scriptler.config.Script;
 import org.jenkinsci.plugins.scriptler.config.ScriptlerConfiguration;
 import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
@@ -108,7 +107,7 @@ public class ScriptlerPluginImpl extends Plugin {
         for (Script script : ScriptlerConfiguration.getConfiguration().getScripts()) {
             File scriptFile = new File(ScriptlerManagement.getScriptDirectory(), script.getScriptPath());
             try{
-                String scriptSource = FileUtils.readFileToString(scriptFile, "UTF-8");
+                String scriptSource = ScriptHelper.readScriptFromFile(scriptFile);
     
                 // we cannot do that during start since the ScriptApproval is not yet loaded
                 // and only after JOB_LOADED to have the securityRealm configured

--- a/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.scriptler.config.Parameter;
 import org.jenkinsci.plugins.scriptler.config.Script;
 import org.jenkinsci.plugins.scriptler.config.ScriptlerConfiguration;
@@ -40,7 +39,7 @@ public class SyncUtil {
         // if not, add it to the configuration
         for (File file : availablePhysicalScripts) {
             if (cfg.getScriptById(file.getName()) == null) {
-                final ScriptInfo info = ScriptHelper.extractScriptInfo(FileUtils.readFileToString(file, "UTF-8"));
+                final ScriptInfo info = ScriptHelper.extractScriptInfo(ScriptHelper.readScriptFromFile(file));
                 if (info != null) {
                     final List<String> paramList = info.getParameters();
                     Parameter[] parameters = new Parameter[paramList.size()];

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.scriptler.share.gh;
 
 import hudson.Extension;
-import hudson.Util;
 import hudson.ProxyConfiguration;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.scriptler.share.CatalogInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfoCatalog;
@@ -79,13 +80,9 @@ public class GHCatalog extends ScriptInfoCatalog<ScriptInfo> {
     @Override
     public String getScriptSource(ScriptInfo scriptInfo) {
 
-        try {
-
-            final String scriptUrl = CATALOG_INFO.getReplacedDownloadUrl(scriptInfo.getName(), scriptInfo.getId());
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Util.copyStreamAndClose(ProxyConfiguration.open(new URL(scriptUrl)).getInputStream(), out);
-            return out.toString("UTF-8");
-
+        final String scriptUrl = CATALOG_INFO.getReplacedDownloadUrl(scriptInfo.getName(), scriptInfo.getId());
+        try (InputStream is = ProxyConfiguration.getInputStream(new URL(scriptUrl))) {
+            return IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "not abe to load script sources from GH for: " + scriptInfo, e);
         }

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
@@ -61,7 +61,8 @@
 
 			<h1>${%Upload new Script}</h1>
 			<div style="margin-bottom: 1em;">
-				${%uploadtext}
+				${%uploadtext}<br/>
+				${%UploadEncoding}
               </div>
 			<f:form method="post" action="uploadScript" name="uploadScript"
 				enctype="multipart/form-data">

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
@@ -35,7 +35,7 @@
 				${%Example}
 				<pre>println System.getenv("PATH")</pre>
 			</p>
-			<f:form method="post" action="scriptAdd">
+			<f:form method="post" name="scriptAdd" action="scriptAdd">
 			    <f:entry title="${%Id}">
                     <f:textbox name="id" />
                 </f:entry>
@@ -52,8 +52,7 @@
                     <f:checkbox name="onlyMaster" checked="${script.onlyMaster}" />
 		</f:entry>
 				<f:entry title="${%Script}">
-					<textarea id="script" name="script" class="script">
-					</textarea>
+					<textarea id="script" name="script" class="${h.isUnitTest ? '' : 'script'}"/>
 				</f:entry>
 				<f:block>
 					<f:submit value="${%Submit}" />

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.properties
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.properties
@@ -25,7 +25,8 @@ intro=\
   save it. Later you will be able to execute it on any slave/node. Useful for trouble-shooting and diagnostics. \
   Use the ''println'' command to see the output (if you use <tt>System.out</tt>, \
   it will go to the server''s stdout, which is harder to see.). If you think your script might be useful to others too, please share it on <a href="https://github.com/jenkinsci/jenkins-scripts" target="_blank">https://github.com/jenkinsci/jenkins-scripts</a>.
-uploadtext=Select a Groovy script from your local system to be uploaded (*.groovy). 
+uploadtext=Select a Groovy script from your local system to be uploaded (*.groovy).
+UploadEncoding=Uploaded files should be encoded with UTF-8.
 Permission = Allow usage in build step
 Restriction = Restriction
 RestrictionDescription = Script is always executed on Master

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/show.jelly
@@ -26,12 +26,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/scriptler">
-	<script src="${it.pluginResourcePath}lib/codemirror.js"></script>
-	<link rel="stylesheet" href="${it.pluginResourcePath}lib/codemirror.css" ></link>
-	<script src="${it.pluginResourcePath}mode/clike/clike.js"></script>
-	<link rel="stylesheet" href="${it.pluginResourcePath}mode/clike/clike.css" ></link>
-	<style>.CodeMirror {border: 2px inset #dee;}</style>
-	
 	<!--
 	Concerning the "type" attribute, as it's a popup we desire to have full size usage of the screen,
 	not used in core version required by this plugin but not disturbing the correct processing
@@ -70,7 +64,7 @@ THE SOFTWARE.
 	                    </p:blockWrapper>
 	                </f:block>					
 					<f:entry title="${%Script}">
-						<textarea id="script" name="script" style="width:100%; height:20em">
+						<textarea id="script" name="script" class="script">
 							${script.script}
 						</textarea>
 					</f:entry>
@@ -78,12 +72,6 @@ THE SOFTWARE.
 			</f:form>
 		</l:main-panel>
 	</l:layout>
-	<script>
-      var editor = CodeMirror.fromTextArea(document.getElementById("script"), {
-        lineNumbers: true,
-        matchBrackets: true,
-        mode: "text/x-groovy",
-        readOnly: true
-      });
-    </script>
+	<st:adjunct includes="org.kohsuke.stapler.codemirror.mode.clike.clike"/>
+	<st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerEncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerEncodingTest.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.scriptler;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class ScriptlerEncodingTest {
+    private static final String SCRIPT_ID = "encodingTest.groovy";
+    private static final String INTERNATIONALIZED_SCRIPT = "def myString = '3.2.0\u00df1'\n" +
+            "println myString.replaceAll(/(\u00df|\\ RC\\ )/,'.')\n";
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private static Charset previousDefaultCharset;
+
+    @Before
+    public void overwriteDefaultCharset() throws Exception {
+        Field defaultCharset = Charset.class.getDeclaredField("defaultCharset");
+        defaultCharset.setAccessible(true);
+        previousDefaultCharset = (Charset) defaultCharset.get(null);
+        defaultCharset.set(null, StandardCharsets.ISO_8859_1);
+        assumeThat(Charset.defaultCharset().name(), is("ISO-8859-1"));
+    }
+
+    @After
+    public void restoreDefaultCharset() throws Exception {
+        Field defaultCharset = Charset.class.getDeclaredField("defaultCharset");
+        defaultCharset.setAccessible(true);
+        defaultCharset.set(null, previousDefaultCharset);
+    }
+
+    @Test
+    @Issue("JENKINS-59841")
+    public void testNonAsciiEncodingSaving() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        HtmlPage scriptAddPage = wc.goTo("scriptler/scriptSettings");
+        HtmlForm scriptAddForm = scriptAddPage.getFormByName("scriptAdd");
+        ((HtmlTextInput) scriptAddForm.getInputByName("id")).setText(SCRIPT_ID);
+        ((HtmlTextInput) scriptAddForm.getInputByName("name")).setText("Encoding Test");
+        scriptAddForm.getInputByName("nonAdministerUsing").setChecked(true);
+        scriptAddForm.getTextAreaByName("script").setText(INTERNATIONALIZED_SCRIPT);
+
+        HtmlPage scriptAddPage1 = j.submit(scriptAddForm);
+        j.assertGoodStatus(scriptAddPage1);
+
+        HtmlPage showScriptPage = wc.goTo("scriptler/showScript?id=" + SCRIPT_ID);
+        j.assertGoodStatus(showScriptPage);
+        HtmlTextArea script = showScriptPage.getElementByName("script");
+        assertEquals(INTERNATIONALIZED_SCRIPT, script.getText());
+    }
+}


### PR DESCRIPTION
JENKINS-59841 describes an issue that occurs when the default character set on a system is not UTF-8: writing of files out to the system when the script was entered in the web form used the default character set of the system, but reading the files back used UTF-8 encoding. These character sets are compatible with basic ASCII characters, but anything outside of that is ripe for misinterpretation.

Fix this by writing files out to the system using UTF-8 and add a unit test to ensure that the default character set being something other than UTF-8 doesn't cause any more issues.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
