### PR TITLE
Fix the GitHub origin URL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
@@ -31,7 +31,7 @@ public class GHCatalog implements ScriptInfoCatalog<ScriptInfo> {
 
     private final static Logger LOGGER = Logger.getLogger(GHCatalog.class.getName());
 
-    public static final String REPO_BASE = "https://github.com/jenkinsci/jenkins-scripts/tree/master/scriptler";
+    public static final String REPO_BASE = "https://github.com/jenkinsci/jenkins-scripts/blob/master/scriptler/{1}";
     public static final String DOWNLOAD_URL = "https://raw.github.com/jenkinsci/jenkins-scripts/master/scriptler/{1}";
 
     public static final CatalogInfo CATALOG_INFO = new CatalogInfo("gh", REPO_BASE, REPO_BASE, DOWNLOAD_URL);


### PR DESCRIPTION
When putting a link to the original script on a downloaded script in the
script catalog, the generated link went to the repository generally and
didn't directly link to the file that was downloaded. Change the URL so
that it will link directly to the downloaded script.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
