### PR TITLE
Switch away from JSR-305 annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -5,6 +5,7 @@ package org.jenkinsci.plugins.scriptler.builder;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -45,8 +46,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.Serializable;
@@ -89,7 +88,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         this.propagateParams = propagateParams;
     }
 
-    private @Nonnull Map<String, String> checkGenericData() {
+    private @NonNull Map<String, String> checkGenericData() {
         Map<String, String> errors = new HashMap<>();
 
         Script script = ScriptHelper.getScript(scriptId, true);
@@ -104,7 +103,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         return errors;
     }
 
-    private void checkPermission(@Nonnull Map<String, String> errors){
+    private void checkPermission(@NonNull Map<String, String> errors){
         if(Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)){
             // user has right to add / edit Scripler steps
             return;
@@ -137,7 +136,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         return this;
     }
 
-    private boolean hasSameScriptlerBuilderInProject(@Nonnull Project<?, ?> project, @Nonnull ScriptlerBuilder targetBuilder){
+    private boolean hasSameScriptlerBuilderInProject(@NonNull Project<?, ?> project, @NonNull ScriptlerBuilder targetBuilder){
         List<ScriptlerBuilder> allScriptlerBuilders = _getAllScriptlerBuildersFromProject(project);
         for (ScriptlerBuilder builder : allScriptlerBuilders) {
             if(targetBuilder.equals(builder)){
@@ -148,7 +147,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         return false;
     }
 
-    private @Nonnull List<ScriptlerBuilder> _getAllScriptlerBuildersFromProject(@Nonnull Project<?, ?> project){
+    private @NonNull List<ScriptlerBuilder> _getAllScriptlerBuildersFromProject(@NonNull Project<?, ?> project){
         return project.getBuildersList().getAll(ScriptlerBuilder.class);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguration.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.scriptler.config;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.XmlFile;
 import hudson.model.Saveable;
@@ -49,8 +50,6 @@ import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-
-import javax.annotation.Nonnull;
 
 /**
  */
@@ -97,7 +96,7 @@ public final class ScriptlerConfiguration extends ScriptSet implements Saveable 
         return new XmlFile(XSTREAM, new File(ScriptlerManagement.getScriptlerHomeDirectory(), "scriptler.xml"));
     }
 
-    public static @Nonnull ScriptlerConfiguration load() throws IOException {
+    public static @NonNull ScriptlerConfiguration load() throws IOException {
         XmlFile f = getXmlFile();
         if (f.exists()) {
             // As it might be that we have an unsorted set, we ensure the

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.scriptler.share.gh;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
 
@@ -17,8 +18,6 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.scriptler.share.CatalogInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfo;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfoCatalog;
-
-import javax.annotation.CheckForNull;
 
 /**
  * Provides access to the scriptler scripts shared at https://github.com/jenkinsci/jenkins-scripts

--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.scriptler.util;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -15,7 +16,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;

--- a/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilderTest.java
@@ -29,6 +29,7 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionList;
 import hudson.model.FileParameterValue;
 import hudson.model.FreeStyleProject;
@@ -49,7 +50,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
-import javax.annotation.CheckForNull;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;


### PR DESCRIPTION
The javax.annotations package from JSR 305 has been marked EOL and is
removed from newer Jenkins versions. Replace annotations from there with
their equivalents from FindBugs, which serve the same purpose.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
