### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 		<jenkins.version>2.332.1</jenkins.version>
-		<java.level>8</java.level>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/jenkinsci/scriptler-plugin.git</connection>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.