### PR TITLE
[JENKINS-71015] Re-Support Job DSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -40,6 +40,7 @@ import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
 import org.jenkinsci.plugins.scriptler.util.UIHelper;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -81,6 +82,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         this(builderId, scriptId, propagateParams, Arrays.asList(Objects.requireNonNull(parameters)));
     }
 
+    @DataBoundConstructor
     public ScriptlerBuilder(String builderId, String scriptId, boolean propagateParams, @NonNull List<Parameter> parameters) {
         this.builderId = builderId;
         this.scriptId = scriptId;

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Parameter.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Parameter.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.scriptler.config;
 
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
 import java.util.*;
@@ -25,6 +26,7 @@ public class Parameter implements Serializable {
         value = object.getString(VALUE);
     }
 
+    @DataBoundConstructor
     public Parameter(String name, String value) {
         this.name = name;
         this.value = value;


### PR DESCRIPTION
### Detail

 - After active-choices-plugin 2.6.0, it use `ScriptlerBuilder` instead of `scriptlerScriptId` and `parameter`. But `ScriptlerBuilder` doesn't have `DataBoundConstructor` annotation, so Job DSL can't recognize the scriptler script syntax in `cascadeChoiceParameter`.
 - Before 2.5.7
   - ![image](https://github.com/biouno/uno-choice-plugin/assets/16630665/3ed374fd-5744-4f3c-b567-aa6fedad0450)
   - ```
     scriptlerScript {
       scriptlerScriptId(String value)
       parameters {
         scriptlerScriptParameter {
           name(String value)
         }
       }
     }
     ```
 - After 2.6.0
   - ![image](https://github.com/biouno/uno-choice-plugin/assets/16630665/cec02a53-486f-424b-bebe-c25977c1a46a)
 - After this commit
   - ![image](https://github.com/jenkinsci/scriptler-plugin/assets/16630665/8036bfa7-777d-4a2d-9ae8-d75b470bae47)
   - ```
     scriptlerScript {
       scriptlerBuilder {
         buildersId(String value)
         scriptId(String value)
         propagateParams(boolean value)
         parameters {
           parameter {
             name(String value)
             value(String value)
           }
         }
       }
       isSandboxed(Boolean value)
       scriptlerScriptId(String value)
     }
     ```


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
