### PR TITLE
Remove reference to Prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<gitHubRepo>jenkinsci/scriptler-plugin</gitHubRepo>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-		<jenkins.version>2.426</jenkins.version>
+		<jenkins.version>2.426.1</jenkins.version>
 	</properties>
 	<scm>
 		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.426.x</artifactId>
-                <version>2555.v3190a_8a_c60c6</version>
+                <version>2582.v830625dd636c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<gitHubRepo>jenkinsci/scriptler-plugin</gitHubRepo>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-		<jenkins.version>2.387.3</jenkins.version>
+		<jenkins.version>2.426</jenkins.version>
 	</properties>
 	<scm>
 		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
@@ -42,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.426.x</artifactId>
+                <version>2555.v3190a_8a_c60c6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runScript.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/runScript.jelly
@@ -122,7 +122,7 @@ THE SOFTWARE.
 				<div align="right">
 					<f:submit value="${%Run}" name="run" />
 				</div>
-				<script>$('script').focus();</script>
+				<script>document.getElementById('script').focus();</script>
 			</form>
 			<j:if test="${output!=null}">
 				<h2>${%Result}</h2>

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/scriptler">
 
-    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype" includes="org.kohsuke.stapler.bind"/>
+    <st:adjunct includes="org.kohsuke.stapler.bind"/>
 	<st:once>
 		<script type="text/javascript" src="${resURL}/plugin/scriptler/lib/scriptler.js" />
 	</st:once>


### PR DESCRIPTION
When running on recent releases of Jenkins core with Prototype removed, a scary-looking but harmless warning (stack trace) is printed to the Jenkins log:

```
2023-04-04 03:12:57.973+0000 [id=264]        WARNING        o.k.s.f.adjunct.AdjunctsInPage#findNeeded: No such adjunct found: org.kohsuke.stapler.framework.prototype.prototype
org.kohsuke.stapler.framework.adjunct.NoSuchAdjunctException: Neither org.kohsuke.stapler.framework.prototype.prototype.css, .js, .html, nor .jelly were found
        at org.kohsuke.stapler.framework.adjunct.Adjunct.<init>(Adjunct.java:125)
        at org.kohsuke.stapler.framework.adjunct.AdjunctManager.get(AdjunctManager.java:148)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.findNeeded(AdjunctsInPage.java:161)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.assumeIncluded(AdjunctsInPage.java:131)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.assumeIncluded(AdjunctsInPage.java:125)
```

This PR updates the core baseline to the (forthcoming) LTS release (2.426.x), which removes the harmless warning.

### Testing done

Reproduced the warning on a recent weekly, and verified that with this change the warning is no longer printed.