### PR TITLE
Fix generating javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
 		<changelist>999999-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/scriptler-plugin</gitHubRepo>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
 		<jenkins.version>2.426.1</jenkins.version>
 	</properties>
 	<scm>

--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -302,7 +302,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
     }
 
     /**
-     * Automatically registered by {@link XStream2.AssociatedConverterImpl#findConverter(Class)}
+     * Automatically registered by XStream2.AssociatedConverterImpl#findConverter(Class)
      * Process the class regularly but add a check after that
      */
     @SuppressWarnings("unused") // discovered dynamically

--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/UIHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/UIHelper.java
@@ -16,7 +16,7 @@ public class UIHelper {
     /**
      * Extracts the parameters from the given request
      *
-     * @param req
+     * @param json
      *            the request potentially containing parameters
      * @return parameters - might be an empty array, but never <code>null</code>.
      */


### PR DESCRIPTION
Enables javadoc generation to ensure javadoc URLs on pages like plugins.jenkins.io, javadoc.jenkins.io, etc. are functional upon click.