### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/git/GitScriptlerRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/git/GitScriptlerRepository.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import jenkins.model.Jenkins;
 

--- a/src/main/java/org/jenkinsci/plugins/scriptler/git/GitScriptlerRepositorySSHAccess.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/git/GitScriptlerRepositorySSHAccess.java
@@ -7,7 +7,7 @@ import hudson.Extension;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.UploadPack;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.