### PR TITLE
Format JavaScript files with Prettier

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/confirm-remove.js
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/confirm-remove.js
@@ -1,9 +1,11 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const removeScriptButtons = document.querySelectorAll(".scriptler-remove-script-form");
-    removeScriptButtons.forEach(button => button.addEventListener("click", (e) => {
-        const name = e.currentTarget.getAttribute('data-name');
-        if (!confirm("Sure you want to delete [" + name + "]?")) {
-            e.preventDefault();
-        }
-    }));
+document.addEventListener("DOMContentLoaded", () => {
+  const removeScriptButtons = document.querySelectorAll(".scriptler-remove-script-form");
+  removeScriptButtons.forEach((button) =>
+    button.addEventListener("click", (e) => {
+      const name = e.currentTarget.getAttribute("data-name");
+      if (!confirm("Sure you want to delete [" + name + "]?")) {
+        e.preventDefault();
+      }
+    }),
+  );
 });

--- a/src/main/webapp/lib/scriptler.js
+++ b/src/main/webapp/lib/scriptler.js
@@ -1,45 +1,41 @@
-
-function scriptler_initDetailLink(rootURL, referenceTag){
-   var itemURL = referenceTag.getAttribute('data-item-url');
-   var selId = referenceTag.value;
-   var all = new Array();
-   all = document.getElementsByName('scriptlerScriptId');
-   for(var i = 0; i < all.length; i++) {
-	   if(referenceTag == all.item(i)){
-		   var detailsLinkTag = document.getElementsByName('showScriptlerDetailLink').item(i);
-		   if(selId.length != 0){
-			   detailsLinkTag .href=rootURL+"/" + itemURL + "scriptler/showScript?id=".concat(selId);
-			   detailsLinkTag .style.display = 'block';
-			}else{
-			   detailsLinkTag .style.display = 'none';
-			}
-	   }
-   }
+function scriptler_initDetailLink(rootURL, referenceTag) {
+  var itemURL = referenceTag.getAttribute("data-item-url");
+  var selId = referenceTag.value;
+  var all = new Array();
+  all = document.getElementsByName("scriptlerScriptId");
+  for (var i = 0; i < all.length; i++) {
+    if (referenceTag == all.item(i)) {
+      var detailsLinkTag = document.getElementsByName("showScriptlerDetailLink").item(i);
+      if (selId.length != 0) {
+        detailsLinkTag.href = rootURL + "/" + itemURL + "scriptler/showScript?id=".concat(selId);
+        detailsLinkTag.style.display = "block";
+      } else {
+        detailsLinkTag.style.display = "none";
+      }
+    }
+  }
 }
 
-
-function scriptler_descArguments(referenceTag, params){
-   var all = new Array();
-   all = document.getElementsByName('scriptlerScriptId');
-   for(var i = 0; i < all.length; i++) {
-	   if(referenceTag == all.item(i)){
-		   var desc = "";
-		   for(var j = 0; j < params.length; j++) {
-			   desc += j+": "+ params[j].name +" ";
-		   }
-		   var descriptionTag = document.getElementsByName('scriptlerParameters').item(i);
-		   descriptionTag.innerText = desc;
-	   }
-    }	   
+function scriptler_descArguments(referenceTag, params) {
+  var all = new Array();
+  all = document.getElementsByName("scriptlerScriptId");
+  for (var i = 0; i < all.length; i++) {
+    if (referenceTag == all.item(i)) {
+      var desc = "";
+      for (var j = 0; j < params.length; j++) {
+        desc += j + ": " + params[j].name + " ";
+      }
+      var descriptionTag = document.getElementsByName("scriptlerParameters").item(i);
+      descriptionTag.innerText = desc;
+    }
+  }
 }
 
-function scriptler_showParams(referenceTag, scriptId){
-	scriptlerBuilderDesc.getParameters(scriptId, function(t) {
-		var params = t.responseObject();
-		if(params != null){
-			scriptler_descArguments(referenceTag, params);
-		}
-    });
+function scriptler_showParams(referenceTag, scriptId) {
+  scriptlerBuilderDesc.getParameters(scriptId, function (t) {
+    var params = t.responseObject();
+    if (params != null) {
+      scriptler_descArguments(referenceTag, params);
+    }
+  });
 }
-
-


### PR DESCRIPTION
These files were difficult to read and edit due to inconsistent indentation within the same file (spaces and tabs within the same file) as well as odd-numbered indentation (3 spaces), which isn't supported by Prettier (the code formatting tool for JavaScript used in the Jenkins project). This PR uses Prettier to format these source files using the same configuration used for Jenkins core. This makes it easier to read and edit the files, especially for developers who are used to the coding style used in Jenkins core. No other changes were made to the files other than running Prettier.