### PR TITLE
[JENKINS-74741] Migrate from `FromApply#applyResponse` in `ScriptlerBuilder.java`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,9 @@
     <spotless.check.skip>false</spotless.check.skip>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <!-- TODO: switch back to the LTS baseline once the CSP fix is in LTS -->
+    <!--<jenkins.version>${jenkins.baseline}.1</jenkins.version>-->
+    <jenkins.version>2.482</jenkins.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -437,11 +437,10 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node)
                 throws IOException, ServletException {
             if (FormApply.isApply(req)) {
-                String script = buildMessages()
-                        .map(QuotedStringTokenizer::quote)
-                        .map(error -> "notificationBar.show(" + error + ",notificationBar.ERROR)")
-                        .collect(Collectors.joining(""));
-                FormApply.applyResponse(script).generateResponse(req, rsp, node);
+                String script =
+                        buildMessages().map(QuotedStringTokenizer::quote).collect(Collectors.joining(""));
+                FormApply.showNotification(script, FormApply.NotificationType.ERROR)
+                        .generateResponse(req, rsp, node);
             } else {
                 new Failure(getAggregatedMessage()).generateResponse(req, rsp, node);
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74741

`FormApply#applyResponse` is deprecated in favor of CSP compatible `FormApply#showNotification` available since version 2.482 of Jenkins.

### Testing done

[Before the change](https://www.youtube.com/watch?v=Jh0Rvn5VQAU)
[After the change](https://www.youtube.com/watch?v=2KoB_Po4x9c)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
