### PR TITLE
Fetch scripts from the `main` branch of the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Release date: _Nov 7, 2012_
     Would like to create/use a central "catalog" . . . 
 -   Scriptler now understands the format for shared scripts also when
     first time pushed via git into Scriptler (Format description:
-    <https://github.com/jenkinsci/jenkins-scripts/tree/master/scriptler#scriptler-scripts>
+    <https://github.com/jenkinsci/jenkins-scripts/tree/main/scriptler#scriptler-scripts>
     )
 -   now depends on the [Git Server
     Plugin](https://wiki.jenkins.io/display/JENKINS/Git+Server+Plugin)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Besides administering your scripts, Scriptler also provides a way to
 share scripts between users via hosted script catalogs on the
 internet.  
 On GitHub at
-<https://github.com/jenkinsci/jenkins-scripts/tree/master/scriptler> you
+<https://github.com/jenkinsci/jenkins-scripts/tree/main/scriptler> you
 are not only able to find scripts and import it via scriptler in to your
 Jenkins instance, but can also share your own scripts. Just send a pull
 request to <https://github.com/jenkinsci/jenkins-scripts/> and your

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/CentralScriptJsonCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/CentralScriptJsonCatalog.java
@@ -12,8 +12,8 @@ import net.sf.json.JsonConfig;
 import org.jenkinsci.plugins.scriptler.share.ScriptInfo;
 
 /**
- * Gets the GitHub catalog from <a href="http://mirrors.jenkins-ci.org/updates/updates/org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json">jenkins-ci/org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json</a>. This catalog is updated by a background crawler on the
- * Jenkins infrastructure site.
+ * Gets the GitHub catalog from <a href="https://mirrors.updates.jenkins.io/updates/org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json">jenkins.io/org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json</a>.
+ * This catalog is updated by <a href="https://github.com/jenkins-infra/crawler/blob/main/scriptler.groovy">a background crawler on the Jenkins infrastructure site</a>.
  *
  * @author Dominik Bartholdi (imod)
  */

--- a/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/share/gh/GHCatalog.java
@@ -31,8 +31,10 @@ public class GHCatalog implements ScriptInfoCatalog<ScriptInfo> {
 
     private static final Logger LOGGER = Logger.getLogger(GHCatalog.class.getName());
 
-    public static final String REPO_BASE = "https://github.com/jenkinsci/jenkins-scripts/blob/master/scriptler/{1}";
-    public static final String DOWNLOAD_URL = "https://raw.github.com/jenkinsci/jenkins-scripts/master/scriptler/{1}";
+    private static final String REPO = "jenkinsci/jenkins-scripts";
+    private static final String BRANCH = "main";
+    public static final String REPO_BASE = "https://github.com/" + REPO + "/blob/" + BRANCH + "/scriptler/{1}";
+    public static final String DOWNLOAD_URL = "https://raw.github.com/" + REPO + "/" + BRANCH + "/scriptler/{1}";
 
     public static final CatalogInfo CATALOG_INFO = new CatalogInfo("gh", REPO_BASE, REPO_BASE, DOWNLOAD_URL);
 

--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
@@ -186,12 +186,12 @@ public final class ScriptHelper {
     }
 
     /**
-     * Returns the meta info of a script body, which must follow <a href="https://github.com/jenkinsci/jenkins-scripts/tree/master/scriptler">the convention</a>
+     * Returns the meta info of a script body, which must follow <a href="https://github.com/jenkinsci/jenkins-scripts/tree/main/scriptler">the convention</a>
      *
      * @param fullScriptBody
      *            the script to extract the meta info from
      * @return <code>null</code> if no meta info found
-     * @see <a href="https://github.com/jenkinsci/jenkins-scripts/tree/master/scriptler">...</a>
+     * @see <a href="https://github.com/jenkinsci/jenkins-scripts/tree/main/scriptler">...</a>
      */
     public static ScriptInfo extractScriptInfo(String fullScriptBody) {
         final Matcher matcher = SCRIPT_META_PATTERN.matcher(fullScriptBody);


### PR DESCRIPTION
The jenkinsci/jenkins-scripts repository is switching from `master` as its default branch to `main`. Update references to the repository to use this new branch name.

<!-- Please describe your pull request here. -->

### Testing done

Tested manually that it downloads from the new branch name successfully.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
