### PR TITLE
Register Scriptler permissions on startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,21 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>3.17.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerPermissions.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerPermissions.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.scriptler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
@@ -26,4 +29,13 @@ public final class ScriptlerPermissions {
     public static final Permission BYPASS_APPROVAL = Jenkins.ADMINISTER;
 
     private ScriptlerPermissions() {}
+
+    @SuppressFBWarnings(
+            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "getEnabled return value discarded")
+    @Initializer(after = InitMilestone.PLUGINS_STARTED, before = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void ensurePermissionsRegistered() {
+        CONFIGURE.getEnabled();
+        RUN_SCRIPTS.getEnabled();
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerPermissionsTests.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerPermissionsTests.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.scriptler;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.security.SecurityRealm;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@WithJenkinsConfiguredWithCode
+class ScriptlerPermissionsTests {
+    @ConfiguredWithCode("/casc.yaml")
+    @Test
+    void permissionsAreAvailableOnStartup(JenkinsConfiguredWithCodeRule rule) throws Exception {
+        SecurityRealm realm = rule.createDummySecurityRealm();
+        rule.jenkins.setSecurityRealm(realm);
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken("user", "user");
+        Authentication a = realm.getSecurityComponents().manager2.authenticate(authRequest);
+        assertTrue(rule.jenkins.hasPermission2(a, ScriptlerPermissions.CONFIGURE));
+    }
+}

--- a/src/test/resources/casc.yaml
+++ b/src/test/resources/casc.yaml
@@ -1,0 +1,9 @@
+jenkins:
+  authorizationStrategy:
+    projectMatrix:
+      entries:
+        - group:
+            name: authenticated
+            permissions:
+              - "Scriptler/Configure"
+              - "Scriptler/RunScripts"


### PR DESCRIPTION
Ensure that the Scriptler permissions are registered on Jenkins startup so that we can use them during CasC configuration.

<!-- Please describe your pull request here. -->

### Testing done

Unit test added verifying the permission is available for CasC. Unit test fails without the fix in place.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
