### PR TITLE
JENKINS-74931: Re-add the `script` field

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
@@ -51,6 +51,12 @@ public class Script implements Comparable<Script>, NamedResource, Serializable {
      */
     private transient String scriptText;
 
+    /**
+     * @deprecated Use {@link #getScriptText()} and {@link #setScriptText(String)} instead.
+     */
+    @Deprecated(since = "384")
+    public transient String script;
+
     // User with Scriptler/RUN_SCRIPT permission can add/edit Scriptler step in projects
     public final boolean nonAdministerUsing;
 
@@ -212,8 +218,10 @@ public class Script implements Comparable<Script>, NamedResource, Serializable {
         return getScriptText();
     }
 
+    @SuppressWarnings({"deprecated", "java:S1874"})
     public void setScriptText(String scriptText) {
         this.scriptText = scriptText;
+        script = scriptText;
     }
 
     /**


### PR DESCRIPTION
The Active Choices plugin still depends on this field in order to be able to use the script in a parameter. Re-add it for the moment since the deprecated getter/setter added doesn't seem to be sufficient.

<!-- Please describe your pull request here. -->

### Testing done

None (this is a deprecated field)
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
