### PR TITLE
Use `ArrayList` for storing parameters locally

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +109,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
             @CheckForNull List<Parameter> parameters) {
         this.builderId = builderId;
         this.scriptId = scriptId;
-        this.parameters = parameters == null ? List.of() : List.copyOf(parameters);
+        this.parameters = new ArrayList<>(parameters == null ? List.of() : parameters);
         this.propagateParams = propagateParams;
     }
 
@@ -180,7 +181,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
 
     @NonNull
     public List<Parameter> getParametersList() {
-        return parameters;
+        return Collections.unmodifiableList(parameters);
     }
 
     public String getBuilderId() {

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,2 +1,0 @@
-java.util.ImmutableCollections$ListN
-java.util.ImmutableCollections$List12


### PR DESCRIPTION
Instead of using the Java 11-native `List.of` and `List.copyOf` to store a copy of the parameters list locally, which aren't natively supported by XStream serialization, use `ArrayList`, which is natively supported. When returning the parameters, wrap them in an unmodifiable list to avoid unexpected external modifications.

This unfortunately means that this class is not "immutable" anymore as the parameters can technically be changed, but the current code does not provide a way to accomplish that.

This PR stems from a [discussion on #134](https://github.com/jenkinsci/scriptler-plugin/pull/134#pullrequestreview-2488721169).

<!-- Please describe your pull request here. -->

### Testing done

Verified using existing unit tests plus local testing to see how the class is serialized out to disk.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
