### PR TITLE
Use global MarkupFormatter in ScriptlerManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>antisamy-markup-formatter</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-server</artifactId>
     </dependency>
 
@@ -87,6 +82,12 @@
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>3.18</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
@@ -28,7 +28,6 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
 import hudson.markup.MarkupFormatter;
-import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.model.*;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
@@ -76,8 +75,6 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
     private static final String NOT_APPROVED_YET = "notApprovedYet";
     private static final String CAN_BYPASS_APPROVAL = "canByPassScriptApproval";
     private static final String SCRIPT = "script";
-
-    private static final MarkupFormatter INSTANCE = RawHtmlMarkupFormatter.INSTANCE;
 
     // used in Jelly view
     public Permission getScriptlerRunScripts() {
@@ -154,7 +151,7 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
     }
 
     public MarkupFormatter getMarkupFormatter() {
-        return INSTANCE;
+        return Jenkins.get().getMarkupFormatter();
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerManagementTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerManagementTest.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.scriptler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.markup.MarkupFormatter;
+import hudson.markup.RawHtmlMarkupFormatter;
+import java.io.IOException;
+import java.io.Writer;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ScriptlerManagementTest {
+
+    @Test
+    void markupFormatter(@SuppressWarnings("unused") JenkinsRule r) throws IOException {
+        ScriptlerManagement management = new ScriptlerManagement();
+
+        // save text
+        String text = management.getMarkupFormatter().translate("Save text");
+        assertEquals("Save text", text);
+
+        // dangerous text with global formatter
+        text = management.getMarkupFormatter().translate("<script>alert('PWND!')</script>");
+        assertEquals("&lt;script&gt;alert(&#039;PWND!&#039;)&lt;/script&gt;", text);
+
+        // dangerous text with OWASP formatter
+        r.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
+        text = management.getMarkupFormatter().translate("<script>alert('PWND!')</script>");
+        assertEquals("", text);
+
+        // save text with broken formatter
+        MarkupFormatter formatter = new MarkupFormatter() {
+            @Override
+            public void translate(String markup, @NonNull Writer output) throws IOException {
+                throw new IOException("Oh no!");
+            }
+        };
+        r.jenkins.setMarkupFormatter(formatter);
+        assertThrows(
+                IOException.class, () -> management.getMarkupFormatter().translate("<script>alert('PWND!')</script>"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerManagementTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/ScriptlerManagementTest.java
@@ -15,8 +15,10 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 class ScriptlerManagementTest {
 
+    private static final String DANGEROUS_TEXT = "<script>alert('PWND!')</script>";
+
     @Test
-    void markupFormatter(@SuppressWarnings("unused") JenkinsRule r) throws IOException {
+    void markupFormatter(JenkinsRule r) throws IOException {
         ScriptlerManagement management = new ScriptlerManagement();
 
         // save text
@@ -24,12 +26,12 @@ class ScriptlerManagementTest {
         assertEquals("Save text", text);
 
         // dangerous text with global formatter
-        text = management.getMarkupFormatter().translate("<script>alert('PWND!')</script>");
+        text = management.getMarkupFormatter().translate(DANGEROUS_TEXT);
         assertEquals("&lt;script&gt;alert(&#039;PWND!&#039;)&lt;/script&gt;", text);
 
         // dangerous text with OWASP formatter
         r.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
-        text = management.getMarkupFormatter().translate("<script>alert('PWND!')</script>");
+        text = management.getMarkupFormatter().translate(DANGEROUS_TEXT);
         assertEquals("", text);
 
         // save text with broken formatter
@@ -40,7 +42,6 @@ class ScriptlerManagementTest {
             }
         };
         r.jenkins.setMarkupFormatter(formatter);
-        assertThrows(
-                IOException.class, () -> management.getMarkupFormatter().translate("<script>alert('PWND!')</script>"));
+        assertThrows(IOException.class, () -> management.getMarkupFormatter().translate(DANGEROUS_TEXT));
     }
 }


### PR DESCRIPTION
This change introduces a saver and more consistent behavior when sanitizing / formatting texts.
Plugins should not need to by-pass the global `MarkupFormatter`.

This can be considered a breaking change in case users relied on `RawHtmlMarkupFormatter` to format the texts and have a different global `MarkupFormatter` (e.g. `EscapedMarkupFormatter`) configured. 

### Testing done

Added tests to show that texts are properly escaped using the global `MarkupFormatter`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
