### PR TITLE
JENKINS-75019 - Use uber classloader on built-in node

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -11,13 +11,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Failure;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
-import hudson.model.Project;
+import hudson.model.*;
 import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
@@ -261,7 +255,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
                         parameter.getName(), TokenMacro.expandAll(build, listener, parameter.getValue())));
             }
             final Object output;
-            if (script.onlyBuiltIn) {
+            if (script.onlyBuiltIn || Computer.currentComputer() instanceof Jenkins.MasterComputer) {
                 // When run on the built-in node, make build, launcher, listener available to script
                 output = FilePath.localChannel.call(new ControllerGroovyScript(
                         script.getScriptText(), expandedParams, true, listener, launcher, build));

--- a/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/util/ScriptHelper.java
@@ -171,8 +171,14 @@ public final class ScriptHelper {
             try {
                 Computer comp = Jenkins.get().getComputer(node);
                 TaskListener listener = new StreamTaskListener(sos, StandardCharsets.UTF_8);
-                if (comp == null && NodeNames.BUILT_IN.equals(node)) {
-                    FilePath.localChannel.call(new GroovyScript(scriptTxt, parameters, false, listener));
+                if (NodeNames.BUILT_IN.equals(node)) {
+                    FilePath.localChannel.call(new ControllerGroovyScript(
+                            scriptTxt,
+                            parameters,
+                            false,
+                            listener,
+                            Jenkins.get().createLauncher(listener),
+                            null));
                 } else if (comp != null && comp.getChannel() != null) {
                     comp.getChannel().call(new GroovyScript(scriptTxt, parameters, false, listener));
                 }


### PR DESCRIPTION
Make sure that we are using the uber classloader from the plugin manager when we're running on the built-in node. This is done by ensuring that the `ControllerGroovyScript` class is used for running scripts when we're running on the built-in node, which sets the right classloader.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
