### PR TITLE
Fix Date formatter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/ScriptlerManagement.java
@@ -318,7 +318,7 @@ public class ScriptlerManagement extends ManagementLink implements RootAction {
                     true,
                     originCatalogName,
                     originId,
-                    new SimpleDateFormat("dd MMM yyyy HH:mm:ss a").format(new Date()),
+                    new SimpleDateFormat("dd MMM yyyy HH:mm:ss").format(new Date()),
                     parameters);
         } else {
             // save (overwrite) the meta information


### PR DESCRIPTION
An updated version of SpotBugs (see #151) flags an issue with the date format string that is used when importing a script from the script catalog. Previously, it used a 24-hour time along with an a.m./p.m. indication, which doesn't make much sense. Remove the a.m./p.m. indication so that we have a proper 24-hour timestamp.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
