### PR TITLE
Fix .groovy script detection during sync

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
@@ -86,7 +86,8 @@ public class SyncUtil {
         LOGGER.log(Level.FINE, "Listing files of {0}", scriptDirectory);
 
         try (Stream<Path> contents = Files.list(scriptDirectory)) {
-            return contents.filter(path -> path.getFileName().toString().endsWith(".groovy")).toList();
+            return contents.filter(path -> path.getFileName().toString().endsWith(".groovy"))
+                    .toList();
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/SyncUtil.java
@@ -86,7 +86,7 @@ public class SyncUtil {
         LOGGER.log(Level.FINE, "Listing files of {0}", scriptDirectory);
 
         try (Stream<Path> contents = Files.list(scriptDirectory)) {
-            return contents.filter(path -> path.endsWith(".groovy")).toList();
+            return contents.filter(path -> path.getFileName().toString().endsWith(".groovy")).toList();
         }
     }
 }


### PR DESCRIPTION
Fixes JENKINS-75133.

This PR fixes `.groovy` script detection during Scriptler sync.

`SyncUtil.getAvailableScripts()` was using `Path.endsWith(".groovy")`, but `java.nio.file.Path.endsWith(String)` matches path segments, not filename suffixes. As a result, normal files like `script.groovy` were not detected, so sync/import flows saw an empty list of available scripts.

This caused scripts pushed to the Scriptler Git repository to be written under `scriptler/scripts/`, but not added to `scriptler.xml`, making them invisible in the Scriptler UI.

The fix checks the filename string instead.

### Testing done

Manually tested with a local Jenkins instance using:

```bash
mvn hpi:run