### PR TITLE
Add Configuration as Code support for Scriptler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /dummy.groovy
 /.idea
 /scriptler.iml
+.DS_Store
+**/.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
   <dependencies>
 
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/Script.java
@@ -30,6 +30,8 @@ import hudson.Util;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class Script implements Comparable<Script>, NamedResource, Serializable {
     @Serial
@@ -79,6 +81,7 @@ public class Script implements Comparable<Script>, NamedResource, Serializable {
     /**
      * used to create/update a new script in the UI
      */
+    @DataBoundConstructor
     public Script(
             String id,
             String name,
@@ -219,6 +222,7 @@ public class Script implements Comparable<Script>, NamedResource, Serializable {
         return getScriptText();
     }
 
+    @DataBoundSetter
     @SuppressFBWarnings("PA_PUBLIC_PRIMITIVE_ATTRIBUTE")
     @SuppressWarnings({"deprecated", "java:S1874"})
     public void setScriptText(String scriptText) {

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
@@ -109,13 +109,8 @@ public class ScriptlerConfigurator implements RootElementConfigurator<ScriptlerC
 
                 Mapping scriptMap = node.asMapping();
                 if (scriptMap.containsKey("scriptText")) {
-                    try {
-                        String scriptText =
-                                scriptMap.get("scriptText").asScalar().getValue();
-                        script.setScriptText(scriptText);
-                    } catch (Exception e) {
-                        throw new ConfiguratorException(this, "Failed to parse scriptText for script " + id, e);
-                    }
+                    String scriptText = scriptMap.get("scriptText").asScalar().getValue();
+                    script.setScriptText(scriptText);
                 }
 
                 String fixedFileName = id.endsWith(".groovy") ? id : id + ".groovy";

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
@@ -1,0 +1,197 @@
+package org.jenkinsci.plugins.scriptler.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.Util;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
+import org.jenkinsci.plugins.scriptler.git.GitScriptlerRepository;
+import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+
+@Extension(optional = true)
+public class ScriptlerConfigurator implements RootElementConfigurator<ScriptlerConfiguration> {
+
+    private static final Logger LOGGER = Logger.getLogger(ScriptlerConfigurator.class.getName());
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "scriptler";
+    }
+
+    @Override
+    public ScriptlerConfiguration getTargetComponent(ConfigurationContext context) {
+        return ScriptlerConfiguration.getConfiguration();
+    }
+
+    @Override
+    public Class<ScriptlerConfiguration> getTarget() {
+        return ScriptlerConfiguration.class;
+    }
+
+    @Override
+    @NonNull
+    public Set<Attribute<ScriptlerConfiguration, ?>> describe() {
+        Set<Attribute<ScriptlerConfiguration, ?>> attributes = new TreeSet<>(Comparator.comparing(Attribute::getName));
+        attributes.add(new Attribute<ScriptlerConfiguration, Boolean>("disableRemoteCatalog", Boolean.class));
+        attributes.add(new Attribute<ScriptlerConfiguration, Script>("scripts", Script.class).multiple(true));
+        return attributes;
+    }
+
+    @Override
+    @NonNull
+    public ScriptlerConfiguration check(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        Mapping mapping = config.asMapping();
+
+        if (mapping.containsKey("scripts")) {
+            Sequence sequence;
+            try {
+                sequence = mapping.get("scripts").asSequence();
+            } catch (Exception e) {
+                throw new ConfiguratorException(this, "The 'scripts' attribute must be a sequence (list).", e);
+            }
+
+            Configurator<?> scriptConfigurator = context.lookupOrFail(Script.class);
+
+            for (CNode node : sequence) {
+                scriptConfigurator.check(node, context);
+            }
+        }
+        return ScriptlerConfiguration.getConfiguration();
+    }
+
+    @Override
+    @NonNull
+    public ScriptlerConfiguration configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        Mapping mapping = config.asMapping();
+        ScriptlerConfiguration cfg = ScriptlerConfiguration.getConfiguration();
+
+        if (mapping.containsKey("disableRemoteCatalog")) {
+            try {
+                String boolVal = mapping.get("disableRemoteCatalog").asScalar().getValue();
+                cfg.setDisableRemoteCatalog(Boolean.parseBoolean(boolVal));
+            } catch (Exception e) {
+                throw new ConfiguratorException(this, "Failed to parse disableRemoteCatalog attribute", e);
+            }
+        }
+
+        if (mapping.containsKey("scripts")) {
+            Sequence sequence = mapping.get("scripts").asSequence();
+            SortedSet<Script> newScriptsSet = new TreeSet<>();
+
+            Configurator<?> scriptConfigurator = context.lookupOrFail(Script.class);
+
+            for (CNode node : sequence) {
+                Script script = (Script) scriptConfigurator.configure(node, context);
+                String id = script.getId();
+                if (id == null || id.isEmpty()) {
+                    continue;
+                }
+
+                Mapping scriptMap = node.asMapping();
+                if (scriptMap.containsKey("scriptText")) {
+                    try {
+                        String scriptText =
+                                scriptMap.get("scriptText").asScalar().getValue();
+                        script.setScriptText(scriptText);
+                    } catch (Exception e) {
+                        throw new ConfiguratorException(this, "Failed to parse scriptText for script " + id, e);
+                    }
+                }
+
+                String fixedFileName = id.endsWith(".groovy") ? id : id + ".groovy";
+                fixedFileName = fixedFileName.replace(" ", "_").trim();
+
+                try {
+                    Path scriptDirectory = ScriptlerManagement.getScriptDirectory2();
+                    Path newScriptFile = scriptDirectory.resolve(fixedFileName);
+
+                    if (!Util.isDescendant(scriptDirectory.toFile(), newScriptFile.toFile())) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Folder traversal detected in JCasC configuration for script ID: {0}",
+                                id);
+                        throw new ConfiguratorException(this, "Folder traversal detected in script ID: " + id);
+                    }
+
+                    String text = script.getScriptText();
+                    if (text != null) {
+                        ScriptHelper.writeScriptToFile(newScriptFile, text);
+                        ScriptApproval scriptApproval = ScriptApproval.get();
+                        scriptApproval.configuring(
+                                text,
+                                GroovyLanguage.get(),
+                                ApprovalContext.create().withUser("JCasC"),
+                                true);
+
+                        ExtensionList<GitScriptlerRepository> gitRepos =
+                                ExtensionList.lookup(GitScriptlerRepository.class);
+                        if (!gitRepos.isEmpty()) {
+                            try {
+                                gitRepos.get(0).addSingleFileToRepo(fixedFileName);
+                            } catch (Exception gitEx) {
+                                LOGGER.log(Level.WARNING, "Failed to add script to Git repository: " + id, gitEx);
+                            }
+                        }
+                    }
+                    newScriptsSet.add(script);
+                } catch (ConfiguratorException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new ConfiguratorException(this, "Failed to write script file for " + id, e);
+                }
+            }
+            cfg.setScripts(newScriptsSet);
+        }
+
+        try {
+            cfg.save();
+        } catch (IOException e) {
+            throw new ConfiguratorException(this, "Failed to save scriptler configuration file", e);
+        }
+
+        return cfg;
+    }
+
+    @Override
+    public CNode describe(ScriptlerConfiguration instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("disableRemoteCatalog", instance.isDisableRemoteCatalog());
+
+        Sequence sequence = new Sequence();
+
+        Configurator<Object> rawConfigurator = context.lookupOrFail(Script.class);
+
+        for (Script s : instance.getScripts()) {
+            Script copied = s.copy();
+            Script scriptWithText = ScriptHelper.getScript(s.getId(), true);
+            if (scriptWithText != null) {
+                copied.setScriptText(scriptWithText.getScriptText());
+            }
+
+            sequence.add(rawConfigurator.describe(copied, context));
+        }
+
+        mapping.put("scripts", sequence);
+        return mapping;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfigurator.java
@@ -70,7 +70,7 @@ public class ScriptlerConfigurator implements RootElementConfigurator<ScriptlerC
                 throw new ConfiguratorException(this, "The 'scripts' attribute must be a sequence (list).", e);
             }
 
-            Configurator<?> scriptConfigurator = context.lookupOrFail(Script.class);
+            Configurator<Script> scriptConfigurator = context.lookupOrFail(Script.class);
 
             for (CNode node : sequence) {
                 scriptConfigurator.check(node, context);
@@ -98,10 +98,9 @@ public class ScriptlerConfigurator implements RootElementConfigurator<ScriptlerC
             Sequence sequence = mapping.get("scripts").asSequence();
             SortedSet<Script> newScriptsSet = new TreeSet<>();
 
-            Configurator<?> scriptConfigurator = context.lookupOrFail(Script.class);
-
+            Configurator<Script> scriptConfigurator = context.lookupOrFail(Script.class);
             for (CNode node : sequence) {
-                Script script = (Script) scriptConfigurator.configure(node, context);
+                Script script = scriptConfigurator.configure(node, context);
                 String id = script.getId();
                 if (id == null || id.isEmpty()) {
                     continue;
@@ -174,7 +173,7 @@ public class ScriptlerConfigurator implements RootElementConfigurator<ScriptlerC
 
         Sequence sequence = new Sequence();
 
-        Configurator<Object> rawConfigurator = context.lookupOrFail(Script.class);
+        Configurator<Script> rawConfigurator = context.lookupOrFail(Script.class);
 
         for (Script s : instance.getScripts()) {
             Script copied = s.copy();

--- a/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.scriptler.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@WithJenkinsConfiguredWithCode
+public class ScriptlerConfiguratorTest {
+
+    private static final String IMPORT_SCRIPT_ID = "test-script.groovy";
+    private static final String EXPORT_SCRIPT_ID = "export-test.groovy";
+    private static final String EXPORT_SCRIPT_TEXT = "println 'Export'";
+    private static final String EXPORT_SCRIPT_NAME = "Test script";
+
+    @Test
+    @ConfiguredWithCode("scriptler-config.yaml")
+    public void testImportConfiguration(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) throws Exception {
+        ScriptlerConfiguration config = getActiveConfiguration();
+
+        assertTrue(config.isDisableRemoteCatalog(), "disableRemoteCatalog should be true");
+
+        Set<Script> scripts = config.getScripts();
+        assertEquals(1, scripts.size());
+        assertEquals(IMPORT_SCRIPT_ID, scripts.iterator().next().getId());
+
+        Path scriptFile = ScriptlerManagement.getScriptDirectory2().resolve(IMPORT_SCRIPT_ID);
+        assertTrue(Files.exists(scriptFile), "Script file should exist on disk");
+
+        String fileContent = Files.readString(scriptFile);
+        assertTrue(fileContent.contains("println 'Hello World'"), "File content should match YAML source");
+    }
+
+    @Test
+    public void testExportConfiguration(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) throws Exception {
+        ScriptlerConfiguration config = createMockConfiguration();
+
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+        assertNotNull(configurator, "JCasC failed to discover the ScriptlerConfigurator extension!");
+
+        CNode cNode = configurator.describe(config, context);
+        assertNotNull(cNode);
+        Mapping rootMapping = cNode.asMapping();
+
+        assertEquals("true", rootMapping.get("disableRemoteCatalog").asScalar().getValue());
+        assertEquals(1, rootMapping.get("scripts").asSequence().size());
+
+        Mapping exportedScript = rootMapping.get("scripts").asSequence().get(0).asMapping();
+        assertScalarValue(EXPORT_SCRIPT_ID, exportedScript.get("id"));
+        assertScalarValue(EXPORT_SCRIPT_TEXT, exportedScript.get("scriptText"));
+        assertScalarValue(EXPORT_SCRIPT_NAME, exportedScript.get("name"));
+
+        String fullExportedYaml = executeFullJCasCExport();
+        assertTrue(fullExportedYaml.contains("scriptler:"), "Root element missing from full export");
+        assertTrue(fullExportedYaml.contains(EXPORT_SCRIPT_ID), "Script ID missing from full export");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        getActiveConfiguration().setScripts(new TreeSet<>());
+    }
+
+    private ScriptlerConfiguration getActiveConfiguration() {
+        return ScriptlerConfiguration.getConfiguration();
+    }
+
+    private ScriptlerConfiguration createMockConfiguration() {
+        ScriptlerConfiguration config = getActiveConfiguration();
+        config.setDisableRemoteCatalog(true);
+
+        Script script = new Script(
+                EXPORT_SCRIPT_ID, EXPORT_SCRIPT_NAME, EXPORT_SCRIPT_TEXT, false, Collections.emptyList(), false);
+        script.setScriptText(EXPORT_SCRIPT_TEXT);
+
+        Set<Script> modifiableScripts = new TreeSet<>(config.getScripts());
+        modifiableScripts.add(script);
+        config.setScripts(modifiableScripts);
+        return config;
+    }
+
+    private String executeFullJCasCExport() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(out);
+        return out.toString();
+    }
+
+    private void assertScalarValue(String expected, CNode scalarNode) {
+        assertNotNull(scalarNode, "Target scalar node must not be null");
+        assertEquals(expected, scalarNode.asScalar().getValue());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
@@ -255,36 +255,6 @@ public class ScriptlerConfiguratorTest {
         }
     }
 
-    @Test
-    public void testConfigureHandlesSaveXmlException(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j)
-            throws Exception {
-        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
-        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
-
-        Path scriptlerHome = ScriptlerManagement.getScriptDirectory2().getParent();
-        Path configFilePath = scriptlerHome.resolve("scriptler.xml");
-
-        Files.deleteIfExists(configFilePath);
-        Files.createDirectories(configFilePath);
-
-        try {
-            Mapping rootMapping = new Mapping();
-            rootMapping.put("disableRemoteCatalog", "true");
-            rootMapping.put("scripts", new Sequence());
-
-            ConfiguratorException thrown = assertThrows(
-                    ConfiguratorException.class,
-                    () -> configurator.configure(rootMapping, context),
-                    "The configurator should throw an exception if the global config file cannot be written.");
-
-            assertTrue(
-                    thrown.getMessage().contains("Failed to save scriptler configuration file"),
-                    "Error should report XML configuration file save persistence failure");
-        } finally {
-            Files.deleteIfExists(configFilePath);
-        }
-    }
-
     @AfterEach
     public void tearDown() {
         getActiveConfiguration().setScripts(new TreeSet<>());

--- a/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
@@ -150,29 +150,6 @@ public class ScriptlerConfiguratorTest {
     }
 
     @Test
-    public void testConfigureScriptTextExpectsScalar(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
-        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
-        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
-
-        Mapping scriptMapping = new Mapping();
-        scriptMapping.put("id", "invalid-text-script.groovy");
-        scriptMapping.put("name", "Invalid Text Test");
-        scriptMapping.put("scriptText", new Mapping());
-        scriptMapping.put("parameters", new Sequence());
-
-        Sequence scriptsSequence = new Sequence();
-        scriptsSequence.add(scriptMapping);
-
-        Mapping rootMapping = new Mapping();
-        rootMapping.put("scripts", scriptsSequence);
-
-        assertThrows(
-                ConfiguratorException.class,
-                () -> configurator.configure(rootMapping, context),
-                "The configurator should throw an exception if 'scriptText' cannot be resolved to a scalar string.");
-    }
-
-    @Test
     public void testConfigureRejectsDirectoryTraversal(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
         ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
         Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);

--- a/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptler/config/ScriptlerConfiguratorTest.java
@@ -2,17 +2,22 @@ package org.jenkinsci.plugins.scriptler.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +25,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
+import org.jenkinsci.plugins.scriptler.git.GitScriptlerRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +78,234 @@ public class ScriptlerConfiguratorTest {
         String fullExportedYaml = executeFullJCasCExport();
         assertTrue(fullExportedYaml.contains("scriptler:"), "Root element missing from full export");
         assertTrue(fullExportedYaml.contains(EXPORT_SCRIPT_ID), "Script ID missing from full export");
+    }
+
+    @Test
+    public void testDescribeAttributes(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Set<Attribute<ScriptlerConfiguration, ?>> attributes = configurator.describe();
+
+        assertNotNull(attributes, "Attributes set should not be null");
+        assertEquals(2, attributes.size(), "Should expose exactly 2 configurable attributes");
+
+        boolean hasDisableCatalog = attributes.stream().anyMatch(a -> "disableRemoteCatalog".equals(a.getName()));
+        boolean hasScripts = attributes.stream().anyMatch(a -> "scripts".equals(a.getName()));
+
+        assertTrue(hasDisableCatalog, "Metadata should expose 'disableRemoteCatalog'");
+        assertTrue(hasScripts, "Metadata should expose 'scripts'");
+    }
+
+    @Test
+    public void testCheckScriptsExpectsSequence(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Mapping invalidMapping = new Mapping();
+        invalidMapping.put("scripts", "not-a-sequence-list");
+
+        assertThrows(
+                ConfiguratorException.class,
+                () -> configurator.check(invalidMapping, context),
+                "The configurator should throw an exception if 'scripts' is not a sequence.");
+    }
+
+    @Test
+    public void testConfigureDisableRemoteCatalogExpectsScalar(
+            @SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Mapping invalidMapping = new Mapping();
+        invalidMapping.put("disableRemoteCatalog", new Mapping());
+
+        assertThrows(
+                ConfiguratorException.class,
+                () -> configurator.configure(invalidMapping, context),
+                "The configurator should throw an exception if 'disableRemoteCatalog' cannot be resolved to a scalar.");
+    }
+
+    @Test
+    public void testConfigureScriptWithEmptyIdIsSkipped(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Mapping scriptMapping = new Mapping();
+        scriptMapping.put("id", "");
+        scriptMapping.put("name", "Blank ID Test Script");
+        scriptMapping.put("scriptText", "println 'Skip Me'");
+        scriptMapping.put("parameters", new Sequence());
+
+        Sequence scriptsSequence = new Sequence();
+        scriptsSequence.add(scriptMapping);
+
+        Mapping rootMapping = new Mapping();
+        rootMapping.put("scripts", scriptsSequence);
+
+        ScriptlerConfiguration config = configurator.configure(rootMapping, context);
+
+        assertNotNull(config, "Configuration should return a valid instance");
+        assertTrue(config.getScripts().isEmpty(), "Scripts list should remain empty because the blank ID was skipped");
+    }
+
+    @Test
+    public void testConfigureScriptTextExpectsScalar(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Mapping scriptMapping = new Mapping();
+        scriptMapping.put("id", "invalid-text-script.groovy");
+        scriptMapping.put("name", "Invalid Text Test");
+        scriptMapping.put("scriptText", new Mapping());
+        scriptMapping.put("parameters", new Sequence());
+
+        Sequence scriptsSequence = new Sequence();
+        scriptsSequence.add(scriptMapping);
+
+        Mapping rootMapping = new Mapping();
+        rootMapping.put("scripts", scriptsSequence);
+
+        assertThrows(
+                ConfiguratorException.class,
+                () -> configurator.configure(rootMapping, context),
+                "The configurator should throw an exception if 'scriptText' cannot be resolved to a scalar string.");
+    }
+
+    @Test
+    public void testConfigureRejectsDirectoryTraversal(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Mapping scriptMapping = new Mapping();
+        scriptMapping.put("id", "../../../traversal-exploit");
+        scriptMapping.put("name", "Malicious Script");
+        scriptMapping.put("scriptText", "println 'Exploit'");
+        scriptMapping.put("parameters", new Sequence());
+
+        Sequence scriptsSequence = new Sequence();
+        scriptsSequence.add(scriptMapping);
+
+        Mapping rootMapping = new Mapping();
+        rootMapping.put("scripts", scriptsSequence);
+
+        ConfiguratorException thrown = assertThrows(
+                ConfiguratorException.class,
+                () -> configurator.configure(rootMapping, context),
+                "The configurator should reject folder traversal attempts.");
+
+        assertTrue(
+                thrown.getMessage().contains("Folder traversal detected"),
+                "Error should report directory traversal protection");
+    }
+
+    @Test
+    public void testConfigureHandlesGitRepositoryException(
+            @SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j) {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        GitScriptlerRepository faultyRepo = new GitScriptlerRepository() {
+            @Override
+            public void addSingleFileToRepo(String fileName) {
+                throw new RuntimeException("Simulated Git failure for testing catch block");
+            }
+        };
+
+        ExtensionList<GitScriptlerRepository> repoList = ExtensionList.lookup(GitScriptlerRepository.class);
+        repoList.add(0, faultyRepo);
+
+        try {
+            Mapping scriptMapping = new Mapping();
+            scriptMapping.put("id", "git-fault-test.groovy");
+            scriptMapping.put("name", "Git Test Script");
+            scriptMapping.put("scriptText", "println 'Testing Git exception handling'");
+            scriptMapping.put("parameters", new Sequence());
+
+            Sequence scriptsSequence = new Sequence();
+            scriptsSequence.add(scriptMapping);
+
+            Mapping rootMapping = new Mapping();
+            rootMapping.put("scripts", scriptsSequence);
+
+            ScriptlerConfiguration config = configurator.configure(rootMapping, context);
+
+            assertNotNull(config);
+            assertEquals(
+                    1,
+                    config.getScripts().size(),
+                    "Configuration should succeed despite Git repository logging errors");
+        } finally {
+            repoList.remove(faultyRepo);
+        }
+    }
+
+    @Test
+    public void testConfigureHandlesWriteException(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j)
+            throws Exception {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        String scriptId = "write-fault-test.groovy";
+        Path scriptlerDir = ScriptlerManagement.getScriptDirectory2();
+        Path conflictingDir = scriptlerDir.resolve(scriptId);
+
+        Files.createDirectories(conflictingDir);
+
+        try {
+            Mapping scriptMapping = new Mapping();
+            scriptMapping.put("id", scriptId);
+            scriptMapping.put("name", "Write Fault Script");
+            scriptMapping.put("scriptText", "println 'This write should fail'");
+            scriptMapping.put("parameters", new Sequence());
+
+            Sequence scriptsSequence = new Sequence();
+            scriptsSequence.add(scriptMapping);
+
+            Mapping rootMapping = new Mapping();
+            rootMapping.put("scripts", scriptsSequence);
+
+            ConfiguratorException thrown = assertThrows(
+                    ConfiguratorException.class,
+                    () -> configurator.configure(rootMapping, context),
+                    "The configurator should throw an exception if the file payload cannot be persisted to disk.");
+
+            assertTrue(
+                    thrown.getMessage().contains("Failed to write script file"),
+                    "Error should report file persistence failures");
+        } finally {
+            Files.deleteIfExists(conflictingDir);
+        }
+    }
+
+    @Test
+    public void testConfigureHandlesSaveXmlException(@SuppressWarnings("unused") JenkinsConfiguredWithCodeRule j)
+            throws Exception {
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        Configurator<ScriptlerConfiguration> configurator = context.lookupOrFail(ScriptlerConfiguration.class);
+
+        Path scriptlerHome = ScriptlerManagement.getScriptDirectory2().getParent();
+        Path configFilePath = scriptlerHome.resolve("scriptler.xml");
+
+        Files.deleteIfExists(configFilePath);
+        Files.createDirectories(configFilePath);
+
+        try {
+            Mapping rootMapping = new Mapping();
+            rootMapping.put("disableRemoteCatalog", "true");
+            rootMapping.put("scripts", new Sequence());
+
+            ConfiguratorException thrown = assertThrows(
+                    ConfiguratorException.class,
+                    () -> configurator.configure(rootMapping, context),
+                    "The configurator should throw an exception if the global config file cannot be written.");
+
+            assertTrue(
+                    thrown.getMessage().contains("Failed to save scriptler configuration file"),
+                    "Error should report XML configuration file save persistence failure");
+        } finally {
+            Files.deleteIfExists(configFilePath);
+        }
     }
 
     @AfterEach

--- a/src/test/resources/scriptler-config.yaml
+++ b/src/test/resources/scriptler-config.yaml
@@ -1,0 +1,10 @@
+scriptler:
+  disableRemoteCatalog: true
+  scripts:
+    - id: "test-script.groovy"
+      name: "My Test Script"
+      comment: "A test script deployed via JCasC"
+      scriptText: |
+        println 'Hello World'
+      nonAdministerUsing: false
+      parameters: []


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/2457

Add Configuration as Code support for the Scriptler plugin.

- Add a RootElementConfigurator for Scriptler
- Support importing Scriptler settings and scripts from JCasC
- Support exporting Scriptler configuration
- Persist script contents to the Scriptler script directory

### Testing done

- Added automated tests for JCasC import, export, and round-trip configuration.
- Verified all tests pass.
- Manually verified JCasC import using `mvn hpi:run`.
- Confirmed configured scripts appear in the Scriptler UI.
- Confirmed script files are written to the Scriptler scripts directory.
- Confirmed JCasC export correctly includes the `scriptler` configuration.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
