### PR TITLE
Resolve obsolete TODOs in ScriptlerBuilder and scriptSettings.jelly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptler/builder/ScriptlerBuilder.java
@@ -378,7 +378,7 @@ public class ScriptlerBuilder extends Builder implements Serializable {
         }
 
         public List<Script> getScripts() {
-            // TODO currently only script for RUN_SCRIPT permissions are returned?
+            // Returns only scripts that are allowed to run in a build step.
             List<Script> scriptsForBuilder = new ArrayList<>();
             for (Script script : getConfig().getScripts()) {
                 if (script.nonAdministerUsing) {

--- a/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptler/ScriptlerManagement/scriptSettings.jelly
@@ -70,10 +70,7 @@
 				</f:entry>
 				<f:block>
 					<f:entry title="${File}">
-						<!-- @size is for other browsers, @style is for IE -->
-						<!-- TODO switch to f:file after baseline includes https://github.com/jenkinsci/jenkins/pull/7452 -->
-						<input type="file" name="file" class="jenkins-file-upload" style="width:80%"
-							size='40' />
+						<f:file name="file" />
 					</f:entry>
 				</f:block>
 				<f:block>


### PR DESCRIPTION
Replace deprecated file upload markup with the Jenkins `f:file` tag and remove outdated TODOs by clarifying the intended behavior of the Scriptler builder script list. The script selection continues to expose only scripts explicitly allowed for build execution, while the upload form now uses the standard Jenkins form control instead of the legacy HTML file input.